### PR TITLE
Add Eq & Ord instances to ForeignPtr newtypes. (#42)

### DIFF
--- a/sel/sel.cabal
+++ b/sel/sel.cabal
@@ -43,6 +43,8 @@ library
     Sel.Hashing.Generic
     Sel.Hashing.Password
     Sel.Signing
+  other-modules:
+    Sel.Internal
 
   build-depends:
     , base                >=4.14     && <5

--- a/sel/src/Sel/Hashing/Generic.hs
+++ b/sel/src/Sel/Hashing/Generic.hs
@@ -33,12 +33,13 @@ import Data.ByteString.Unsafe (unsafeUseAsCStringLen)
 import Data.Text (Text)
 import Data.Text.Display
 import qualified Data.Text.Lazy.Builder as Builder
-import Foreign (ForeignPtr, Ptr)
+import Foreign (Ptr)
 import qualified Foreign
-import Foreign.C (CSize, CUChar)
+import Foreign.C (CSize(..), CUChar)
 import Foreign.Storable
-import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
+import Foreign.ForeignPtr
 import LibSodium.Bindings.GenericHashing (cryptoGenericHash, cryptoGenericHashBytes, cryptoGenericHashKeyBytes, cryptoGenericHashKeyGen)
+import Sel.Internal
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
 -- $introduction
@@ -67,22 +68,12 @@ import System.IO.Unsafe (unsafeDupablePerformIO)
 newtype HashKey = HashKey (ForeignPtr CUChar)
 
 instance Eq HashKey where
- (HashKey pk1) == (HashKey pk2) = 
-    let p = unsafeForeignPtrToPtr pk1
-        q = unsafeForeignPtrToPtr pk2
-     in unsafeDupablePerformIO $
-          do p' <- peek p
-             q' <- peek q
-             return (p' == q')
+ (HashKey hk1) == (HashKey hk2) = unsafeDupablePerformIO $  
+   unsafeForeignPtrEq hk1 hk2 cryptoGenericHashKeyBytes
 
 instance Ord HashKey where
-  compare (HashKey pk1) (HashKey pk2) =
-    let p = unsafeForeignPtrToPtr pk1
-        q = unsafeForeignPtrToPtr pk2
-     in unsafeDupablePerformIO $
-          do p' <- peek p
-             q' <- peek q
-             return $ compare p' q'
+  compare (HashKey hk1) (HashKey hk2) = unsafeDupablePerformIO $
+    unsafeForeignPtrOrd hk1 hk2 cryptoGenericHashKeyBytes
 
 -- | Create a new 'HashKey' of size 'cryptoGenericHashKeyBytes'.
 --
@@ -105,22 +96,12 @@ newHashKey = do
 newtype Hash = Hash (ForeignPtr CUChar)
 
 instance Eq Hash where
- (Hash pk1) == (Hash pk2) = 
-    let p = unsafeForeignPtrToPtr pk1
-        q = unsafeForeignPtrToPtr pk2
-     in unsafeDupablePerformIO $
-          do p' <- peek p
-             q' <- peek q
-             return (p' == q')
+ (Hash h1) == (Hash h2) = unsafeDupablePerformIO $  
+   unsafeForeignPtrEq h1 h2 cryptoGenericHashBytes
 
 instance Ord Hash where
-  compare (Hash pk1) (Hash pk2) =
-    let p = unsafeForeignPtrToPtr pk1
-        q = unsafeForeignPtrToPtr pk2
-     in unsafeDupablePerformIO $
-          do p' <- peek p
-             q' <- peek q
-             return $ compare p' q'
+  compare (Hash h1) (Hash h2) = unsafeDupablePerformIO $
+   unsafeForeignPtrOrd h1 h2 cryptoGenericHashBytes
 
 instance Storable Hash where
   sizeOf :: Hash -> Int

--- a/sel/src/Sel/Hashing/Generic.hs
+++ b/sel/src/Sel/Hashing/Generic.hs
@@ -37,7 +37,9 @@ import Foreign (ForeignPtr, Ptr)
 import qualified Foreign
 import Foreign.C (CSize, CUChar)
 import Foreign.Storable
+import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import LibSodium.Bindings.GenericHashing (cryptoGenericHash, cryptoGenericHashBytes, cryptoGenericHashKeyBytes, cryptoGenericHashKeyGen)
+import System.IO.Unsafe (unsafeDupablePerformIO)
 
 -- $introduction
 --
@@ -64,6 +66,24 @@ import LibSodium.Bindings.GenericHashing (cryptoGenericHash, cryptoGenericHashBy
 -- @since 0.0.1.0
 newtype HashKey = HashKey (ForeignPtr CUChar)
 
+instance Eq HashKey where
+ (HashKey pk1) == (HashKey pk2) = 
+    let p = unsafeForeignPtrToPtr pk1
+        q = unsafeForeignPtrToPtr pk2
+     in unsafeDupablePerformIO $
+          do p' <- peek p
+             q' <- peek q
+             return (p' == q')
+
+instance Ord HashKey where
+  compare (HashKey pk1) (HashKey pk2) =
+    let p = unsafeForeignPtrToPtr pk1
+        q = unsafeForeignPtrToPtr pk2
+     in unsafeDupablePerformIO $
+          do p' <- peek p
+             q' <- peek q
+             return $ compare p' q'
+
 -- | Create a new 'HashKey' of size 'cryptoGenericHashKeyBytes'.
 --
 -- @since 0.0.1.0
@@ -83,6 +103,24 @@ newHashKey = do
 --
 -- @since 0.0.1.0
 newtype Hash = Hash (ForeignPtr CUChar)
+
+instance Eq Hash where
+ (Hash pk1) == (Hash pk2) = 
+    let p = unsafeForeignPtrToPtr pk1
+        q = unsafeForeignPtrToPtr pk2
+     in unsafeDupablePerformIO $
+          do p' <- peek p
+             q' <- peek q
+             return (p' == q')
+
+instance Ord Hash where
+  compare (Hash pk1) (Hash pk2) =
+    let p = unsafeForeignPtrToPtr pk1
+        q = unsafeForeignPtrToPtr pk2
+     in unsafeDupablePerformIO $
+          do p' <- peek p
+             q' <- peek q
+             return $ compare p' q'
 
 instance Storable Hash where
   sizeOf :: Hash -> Int

--- a/sel/src/Sel/Hashing/Generic.hs
+++ b/sel/src/Sel/Hashing/Generic.hs
@@ -35,9 +35,9 @@ import Data.Text.Display
 import qualified Data.Text.Lazy.Builder as Builder
 import Foreign (Ptr)
 import qualified Foreign
-import Foreign.C (CSize(..), CUChar)
-import Foreign.Storable
+import Foreign.C (CSize, CUChar)
 import Foreign.ForeignPtr
+import Foreign.Storable
 import LibSodium.Bindings.GenericHashing (cryptoGenericHash, cryptoGenericHashBytes, cryptoGenericHashKeyBytes, cryptoGenericHashKeyGen)
 import Sel.Internal
 import System.IO.Unsafe (unsafeDupablePerformIO)
@@ -68,12 +68,14 @@ import System.IO.Unsafe (unsafeDupablePerformIO)
 newtype HashKey = HashKey (ForeignPtr CUChar)
 
 instance Eq HashKey where
- (HashKey hk1) == (HashKey hk2) = unsafeDupablePerformIO $  
-   unsafeForeignPtrEq hk1 hk2 cryptoGenericHashKeyBytes
+  (HashKey hk1) == (HashKey hk2) =
+    unsafeDupablePerformIO $
+      foreignPtrEq hk1 hk2 cryptoGenericHashKeyBytes
 
 instance Ord HashKey where
-  compare (HashKey hk1) (HashKey hk2) = unsafeDupablePerformIO $
-    unsafeForeignPtrOrd hk1 hk2 cryptoGenericHashKeyBytes
+  compare (HashKey hk1) (HashKey hk2) =
+    unsafeDupablePerformIO $
+      foreignPtrOrd hk1 hk2 cryptoGenericHashKeyBytes
 
 -- | Create a new 'HashKey' of size 'cryptoGenericHashKeyBytes'.
 --
@@ -96,12 +98,14 @@ newHashKey = do
 newtype Hash = Hash (ForeignPtr CUChar)
 
 instance Eq Hash where
- (Hash h1) == (Hash h2) = unsafeDupablePerformIO $  
-   unsafeForeignPtrEq h1 h2 cryptoGenericHashBytes
+  (Hash h1) == (Hash h2) =
+    unsafeDupablePerformIO $
+      foreignPtrEq h1 h2 cryptoGenericHashBytes
 
 instance Ord Hash where
-  compare (Hash h1) (Hash h2) = unsafeDupablePerformIO $
-   unsafeForeignPtrOrd h1 h2 cryptoGenericHashBytes
+  compare (Hash h1) (Hash h2) =
+    unsafeDupablePerformIO $
+      foreignPtrOrd h1 h2 cryptoGenericHashBytes
 
 instance Storable Hash where
   sizeOf :: Hash -> Int

--- a/sel/src/Sel/Hashing/Password.hs
+++ b/sel/src/Sel/Hashing/Password.hs
@@ -46,6 +46,7 @@ import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy.Builder as Builder
 import Foreign hiding (void)
 import Foreign.C
+import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import GHC.IO.Handle.Text (memcpy)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
@@ -63,6 +64,24 @@ import LibSodium.Bindings.Random
 --
 -- @since 0.0.1.0
 newtype PasswordHash = PasswordHash (ForeignPtr CChar)
+
+instance Eq PasswordHash where
+ (PasswordHash pk1) == (PasswordHash pk2) = 
+    let p = unsafeForeignPtrToPtr pk1
+        q = unsafeForeignPtrToPtr pk2
+     in unsafeDupablePerformIO $
+          do p' <- peek p
+             q' <- peek q
+             return (p' == q')
+
+instance Ord PasswordHash where
+  compare (PasswordHash pk1) (PasswordHash pk2) =
+    let p = unsafeForeignPtrToPtr pk1
+        q = unsafeForeignPtrToPtr pk2
+     in unsafeDupablePerformIO $
+          do p' <- peek p
+             q' <- peek q
+             return $ compare p' q'
 
 -- | @since 0.0.1.0
 instance Display PasswordHash where

--- a/sel/src/Sel/Hashing/Password.hs
+++ b/sel/src/Sel/Hashing/Password.hs
@@ -46,7 +46,6 @@ import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy.Builder as Builder
 import Foreign hiding (void)
 import Foreign.C
-import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import GHC.IO.Handle.Text (memcpy)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
@@ -64,24 +63,6 @@ import LibSodium.Bindings.Random
 --
 -- @since 0.0.1.0
 newtype PasswordHash = PasswordHash (ForeignPtr CChar)
-
-instance Eq PasswordHash where
- (PasswordHash pk1) == (PasswordHash pk2) = 
-    let p = unsafeForeignPtrToPtr pk1
-        q = unsafeForeignPtrToPtr pk2
-     in unsafeDupablePerformIO $
-          do p' <- peek p
-             q' <- peek q
-             return (p' == q')
-
-instance Ord PasswordHash where
-  compare (PasswordHash pk1) (PasswordHash pk2) =
-    let p = unsafeForeignPtrToPtr pk1
-        q = unsafeForeignPtrToPtr pk2
-     in unsafeDupablePerformIO $
-          do p' <- peek p
-             q' <- peek q
-             return $ compare p' q'
 
 -- | @since 0.0.1.0
 instance Display PasswordHash where

--- a/sel/src/Sel/Internal.hs
+++ b/sel/src/Sel/Internal.hs
@@ -3,27 +3,33 @@
 
 module Sel.Internal where
 
-import Foreign.C.Types (CSize(..), CInt(..))
+import Foreign.C.Types (CInt (..), CSize (..))
+import Foreign.ForeignPtr (ForeignPtr, withForeignPtr)
 import Foreign.Ptr (Ptr)
-import Foreign.ForeignPtr (withForeignPtr, ForeignPtr)
+
 -- | This calls to C's `memcmp` function, used in lieu of
 -- libsodium's `memcmp` in cases when the return code is necessary.
 foreign import capi unsafe "memcmp"
   memcmp :: Ptr a -> Ptr b -> CSize -> IO CInt
 
-unsafeForeignPtrEq :: ForeignPtr a -> ForeignPtr a -> CSize -> IO Bool
-unsafeForeignPtrEq fptr1 fptr2 size =
- withForeignPtr fptr1 $ \p ->
-   withForeignPtr fptr2 $ \q ->
-     do result <- memcmp p q size 
+-- | Compare if the contents of two `ForeignPtr`s are equal.
+foreignPtrEq :: ForeignPtr a -> ForeignPtr a -> CSize -> IO Bool
+foreignPtrEq fptr1 fptr2 size =
+  withForeignPtr fptr1 $ \p ->
+    withForeignPtr fptr2 $ \q ->
+      do
+        result <- memcmp p q size
         return $ 0 == result
 
-unsafeForeignPtrOrd :: ForeignPtr a -> ForeignPtr a -> CSize -> IO Ordering
-unsafeForeignPtrOrd fptr1 fptr2 size =
- withForeignPtr fptr1 $ \p ->
-   withForeignPtr fptr2 $ \q ->
-     do result <- memcmp p q size 
-        return $ if
-          | result == 0 -> EQ
-          | result < 0 -> LT
-          | otherwise -> GT
+-- | Compare the contents of two `ForeignPtr`s using lexicographical ordering.
+foreignPtrOrd :: ForeignPtr a -> ForeignPtr a -> CSize -> IO Ordering
+foreignPtrOrd fptr1 fptr2 size =
+  withForeignPtr fptr1 $ \p ->
+    withForeignPtr fptr2 $ \q ->
+      do
+        result <- memcmp p q size
+        return $
+          if
+              | result == 0 -> EQ
+              | result < 0 -> LT
+              | otherwise -> GT

--- a/sel/src/Sel/Internal.hs
+++ b/sel/src/Sel/Internal.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE MultiWayIf #-}
+
+module Sel.Internal where
+
+import Foreign.C.Types (CSize(..), CInt(..))
+import Foreign.Ptr (Ptr)
+import Foreign.ForeignPtr (withForeignPtr, ForeignPtr)
+-- | This calls to C's `memcmp` function, used in lieu of
+-- libsodium's `memcmp` in cases when the return code is necessary.
+foreign import capi unsafe "memcmp"
+  memcmp :: Ptr a -> Ptr b -> CSize -> IO CInt
+
+unsafeForeignPtrEq :: ForeignPtr a -> ForeignPtr a -> CSize -> IO Bool
+unsafeForeignPtrEq fptr1 fptr2 size =
+ withForeignPtr fptr1 $ \p ->
+   withForeignPtr fptr2 $ \q ->
+     do result <- memcmp p q size 
+        return $ 0 == result
+
+unsafeForeignPtrOrd :: ForeignPtr a -> ForeignPtr a -> CSize -> IO Ordering
+unsafeForeignPtrOrd fptr1 fptr2 size =
+ withForeignPtr fptr1 $ \p ->
+   withForeignPtr fptr2 $ \q ->
+     do result <- memcmp p q size 
+        return $ if
+          | result == 0 -> EQ
+          | result < 0 -> LT
+          | otherwise -> GT

--- a/sel/src/Sel/Internal.hs
+++ b/sel/src/Sel/Internal.hs
@@ -9,7 +9,7 @@ import Foreign.Ptr (Ptr)
 
 -- | This calls to C's `memcmp` function, used in lieu of
 -- libsodium's `memcmp` in cases when the return code is necessary.
-foreign import capi unsafe "memcmp"
+foreign import capi unsafe "string.h memcmp"
   memcmp :: Ptr a -> Ptr b -> CSize -> IO CInt
 
 -- | Compare if the contents of two `ForeignPtr`s are equal.

--- a/sel/src/Sel/Signing.hs
+++ b/sel/src/Sel/Signing.hs
@@ -42,10 +42,12 @@ import Foreign
   , mallocBytes
   , mallocForeignPtrBytes
   , withForeignPtr
+  , peek
   )
 import Foreign.C (CChar, CSize, CUChar, CULLong)
 import qualified Foreign.Marshal.Array as Foreign
 import qualified Foreign.Ptr as Foreign
+import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import GHC.IO.Handle.Text (memcpy)
 import LibSodium.Bindings.Signing
   ( cryptoSignBytes
@@ -73,10 +75,47 @@ import System.IO.Unsafe (unsafeDupablePerformIO)
 -- @since 0.0.1.0
 newtype PublicKey = PublicKey (ForeignPtr CUChar)
 
+instance Eq PublicKey where
+ (PublicKey pk1) == (PublicKey pk2) = 
+    let p = unsafeForeignPtrToPtr pk1
+        q = unsafeForeignPtrToPtr pk2
+     in unsafeDupablePerformIO $
+          do p' <- peek p
+             q' <- peek q
+             return (p' == q')
+
+instance Ord PublicKey where
+  compare (PublicKey pk1) (PublicKey pk2) =
+    let p = unsafeForeignPtrToPtr pk1
+        q = unsafeForeignPtrToPtr pk2
+     in unsafeDupablePerformIO $
+          do p' <- peek p
+             q' <- peek q
+             return $ compare p' q'
+
+
 -- |
 --
 -- @since 0.0.1.0
 newtype SecretKey = SecretKey (ForeignPtr CUChar)
+
+instance Eq SecretKey where
+ (SecretKey pk1) == (SecretKey pk2) = 
+    let p = unsafeForeignPtrToPtr pk1
+        q = unsafeForeignPtrToPtr pk2
+     in unsafeDupablePerformIO $
+          do p' <- peek p
+             q' <- peek q
+             return (p' == q')
+
+instance Ord SecretKey where
+  compare (SecretKey pk1) (SecretKey pk2) =
+    let p = unsafeForeignPtrToPtr pk1
+        q = unsafeForeignPtrToPtr pk2
+     in unsafeDupablePerformIO $
+          do p' <- peek p
+             q' <- peek q
+             return $ compare p' q'
 
 -- |
 --
@@ -86,6 +125,32 @@ data SignedMessage = SignedMessage
   , messageForeignPtr :: ForeignPtr CUChar
   , signatureForeignPtr :: ForeignPtr CUChar
   }
+
+instance Eq SignedMessage where
+  (SignedMessage len1 msg1 sig1) == (SignedMessage len2 msg2 sig2) =
+    let msg1' = unsafeForeignPtrToPtr msg1
+        msg2' = unsafeForeignPtrToPtr msg2
+        sig1' = unsafeForeignPtrToPtr sig1
+        sig2' = unsafeForeignPtrToPtr sig2
+     in unsafeDupablePerformIO $
+          do m1 <- peek msg1'
+             m2 <- peek msg2'
+             s1 <- peek sig1'
+             s2 <- peek sig2'
+             return $ (len1, m1, s1) == (len2, m2, s2)
+
+instance Ord SignedMessage where
+  compare (SignedMessage len1 msg1 sig1) (SignedMessage len2 msg2 sig2) =
+    let msg1' = unsafeForeignPtrToPtr msg1
+        msg2' = unsafeForeignPtrToPtr msg2
+        sig1' = unsafeForeignPtrToPtr sig1
+        sig2' = unsafeForeignPtrToPtr sig2
+     in unsafeDupablePerformIO $
+          do m1 <- peek msg1'
+             m2 <- peek msg2'
+             s1 <- peek sig1'
+             s2 <- peek sig2'
+             return $ compare (len1, m1, s1) (len2, m2, s2)
 
 -- | Generate a pair of public and secret key.
 --

--- a/sel/src/Sel/Signing.hs
+++ b/sel/src/Sel/Signing.hs
@@ -29,7 +29,8 @@ module Sel.Signing
   , getSignature
   , unsafeGetMessage
   , mkSignature
-  ) where
+  )
+where
 
 import Control.Monad (void)
 import Data.ByteString (ByteString)
@@ -75,12 +76,14 @@ import System.IO.Unsafe (unsafeDupablePerformIO)
 newtype PublicKey = PublicKey (ForeignPtr CUChar)
 
 instance Eq PublicKey where
- (PublicKey pk1) == (PublicKey pk2) = unsafeDupablePerformIO $  
-    unsafeForeignPtrEq pk1 pk2 cryptoSignPublicKeyBytes
+  (PublicKey pk1) == (PublicKey pk2) =
+    unsafeDupablePerformIO $
+      foreignPtrEq pk1 pk2 cryptoSignPublicKeyBytes
 
 instance Ord PublicKey where
-  compare (PublicKey pk1) (PublicKey pk2) = unsafeDupablePerformIO $
-    unsafeForeignPtrOrd pk1 pk2 cryptoSignPublicKeyBytes
+  compare (PublicKey pk1) (PublicKey pk2) =
+    unsafeDupablePerformIO $
+      foreignPtrOrd pk1 pk2 cryptoSignPublicKeyBytes
 
 -- |
 --
@@ -88,12 +91,14 @@ instance Ord PublicKey where
 newtype SecretKey = SecretKey (ForeignPtr CUChar)
 
 instance Eq SecretKey where
- (SecretKey sk1) == (SecretKey sk2) = unsafeDupablePerformIO $  
-   unsafeForeignPtrEq sk1 sk2 cryptoSignSecretKeyBytes
+  (SecretKey sk1) == (SecretKey sk2) =
+    unsafeDupablePerformIO $
+      foreignPtrEq sk1 sk2 cryptoSignSecretKeyBytes
 
 instance Ord SecretKey where
- compare (SecretKey sk1) (SecretKey sk2) = unsafeDupablePerformIO $  
-   unsafeForeignPtrOrd sk1 sk2 cryptoSignSecretKeyBytes
+  compare (SecretKey sk1) (SecretKey sk2) =
+    unsafeDupablePerformIO $
+      foreignPtrOrd sk1 sk2 cryptoSignSecretKeyBytes
 
 -- |
 --
@@ -107,16 +112,16 @@ data SignedMessage = SignedMessage
 instance Eq SignedMessage where
   (SignedMessage len1 msg1 sig1) == (SignedMessage len2 msg2 sig2) =
     unsafeDupablePerformIO $ do
-      result1 <- unsafeForeignPtrEq msg1 msg2 len1
-      result2 <- unsafeForeignPtrEq sig1 sig2 cryptoSignBytes
+      result1 <- foreignPtrEq msg1 msg2 len1
+      result2 <- foreignPtrEq sig1 sig2 cryptoSignBytes
       return $ (len1 == len2) && result1 && result2
 
 instance Ord SignedMessage where
   compare (SignedMessage len1 msg1 sig1) (SignedMessage len2 msg2 sig2) =
     unsafeDupablePerformIO $ do
-      result1 <- unsafeForeignPtrOrd msg1 msg2 len1
-      result2 <- unsafeForeignPtrOrd sig1 sig2 cryptoSignBytes
-      return $ (compare len1 len2) <> result1 <> result2
+      result1 <- foreignPtrOrd msg1 msg2 len1
+      result2 <- foreignPtrOrd sig1 sig2 cryptoSignBytes
+      return $ compare len1 len2 <> result1 <> result2
 
 -- | Generate a pair of public and secret key.
 --


### PR DESCRIPTION
This PR adds Eq and Ord instances for every newtype that wraps around a `ForeignPtr`. These instances convert the foreign pointer to a regular pointer just like the instances in base, then work on the pointer's contents instead of the address or pointer itself.

---

closes https://github.com/haskell-cryptography/libsodium-bindings/issues/42