### PR TITLE
Add flags to use pkg-config and homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,19 @@ The Haskell Cryptography Group presents its suite of libsodium packages:
 
 ## Comparison with other libraries
 
-|                    | Description                                | Dependencies                                                                 | GHC Support        | FFI Convention                 |
-|--------------------|--------------------------------------------|------------------------------------------------------------------------------|--------------------|--------------------------------|
-| `libsodium-bindings` | Low-level FFI bindings                     | `base`                                                                     | Starts with 8.10.7 | Recommended `capi` convention  |
-| `sel`                | High-level Haskell interface               | `base`, `base16`,  `bytestring`, `text` `text-display`, `libsodium-bindings` | Starts with 8.10.7 | Defers to `libsodium-bindings` |
-| `saltine`            | Both FFI bindings and high-level interface | `base`, `bytestring` `deepseq`, `text`, `hashable`, `profunctors`            | Starts with 8.0.2  | Legacy `ccall` convention      |
-| `libsodium`          | Low-level FFI bindings                     | `base`                                                                       | 8.6.5 to 8.10.1    | Legacy `ccall` convention      |
-| `crypto-sodium`      | High-level Haskell interface               | `base`, `bytestring`, `random`, `cereal`, `libsodium`, `memory`,             | Unclear            | Defers to `libsodium`          |
+| Name                 | Description                                | Dependencies                                                                 | GHC Support          
+|----------------------|--------------------------------------------|------------------------------------------------------------------------------|--------------------  
+| `libsodium-bindings` | Low-level FFI bindings                     | `base`                                                                       | Starts with 8.10.7   
+| `sel`                | High-level Haskell interface               | `base`, `base16`,  `bytestring`, `text` `text-display`, `libsodium-bindings` | Starts with 8.10.7 
+| `saltine`            | Both FFI bindings and high-level interface | `base`, `bytestring` `deepseq`, `text`, `hashable`, `profunctors`            | Starts with 8.0.2  
+| `libsodium`          | Low-level FFI bindings                     | `base`                                                                       | 8.6.5 to 8.10.1    
+| `crypto-sodium`      | High-level Haskell interface               | `base`, `bytestring`, `random`, `cereal`, `libsodium`, `memory`,             | Unclear            
+
+| Name                 | FFI Convention                 | Library Discovery
+|----------------------|--------------------------------|-------------------
+| `libsodium-bindings` | Recommended `capi` convention  | `pkg-config`, `homebrew` (macOS-only), cabal-native
+| `saltine`            | Legacy `ccall` convention      | `pkg-config`, cabal-native
+| `libsodium`          | Legacy `ccall` convention      | `pkg-config`
 
 [sel]: https://github.com/haskell-cryptography/libsodium-bindings/blob/main/sel/README.md
 [sel-ci]: https://github.com/haskell-cryptography/libsodium-bindings/actions/workflows/sel.yml/badge.svg

--- a/libsodium-bindings/libsodium-bindings.cabal
+++ b/libsodium-bindings/libsodium-bindings.cabal
@@ -21,19 +21,37 @@ extra-source-files:
   LICENSE
   README.md
 
+flag use-pkg-config
+  description: Use pkg-config to find OpenSSL (macOS and linux only).
+  default:     False
+  manual:      True
+
+flag homebrew-libsodium
+  description: Use Homebrew version of OpenSSL (macOS only).
+  default:     False
+
 source-repository head
   type:     git
   location: https://github.com/haskell-cryptography/libsodium-bindings
 
 common common
-  build-depends:     base >=4.14 && <5
+  build-depends:    base >=4.14 && <5
   ghc-options:
     -Wall -Wcompat -Widentities -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
     -fhide-source-paths -Wno-unused-do-bind -haddock
 
-  pkgconfig-depends: libsodium ==1.0.18
-  default-language:  Haskell2010
+  if (os(osx) && flag(homebrew-libsodium))
+    include-dirs:   /opt/local/include
+    extra-lib-dirs: /user/local/opt/libsodium/lib
+
+  if flag(use-pkg-config)
+    pkgconfig-depends: libsodium ==1.0.18
+
+  else
+    extra-libraries: sodium
+
+  default-language: Haskell2010
 
 common common-rts-options
   ghc-options: -rtsopts -threaded -with-rtsopts=-N

--- a/libsodium-bindings/libsodium-bindings.cabal
+++ b/libsodium-bindings/libsodium-bindings.cabal
@@ -22,12 +22,12 @@ extra-source-files:
   README.md
 
 flag use-pkg-config
-  description: Use pkg-config to find OpenSSL (macOS and linux only).
+  description: Use pkg-config to find Libsodium (macOS and linux only).
   default:     False
   manual:      True
 
 flag homebrew-libsodium
-  description: Use Homebrew version of OpenSSL (macOS only).
+  description: Use Homebrew version of Libsodium (macOS only).
   default:     False
 
 source-repository head


### PR DESCRIPTION
This PR adds darwin-specific flag for homebrew, as well as a manual flag for using pkg-config when needed. Both fallback to cabal-native `extra-libraries` when not enabled.