### PR TITLE
Remove stray wildcard imports

### DIFF
--- a/libsodium-bindings/src/LibSodium/Bindings/AEAD.hs
+++ b/libsodium-bindings/src/LibSodium/Bindings/AEAD.hs
@@ -23,7 +23,7 @@ module LibSodium.Bindings.AEAD
   )
 where
 
-import Foreign.C.Types (CInt (..), CSize (..), CUChar (..), CULLong (..))
+import Foreign.C.Types (CInt (CInt), CSize (CSize), CUChar, CULLong (CULLong))
 import Foreign.Ptr (Ptr)
 
 -- | This function encrypts a message, and then appends the authentication tag

--- a/libsodium-bindings/src/LibSodium/Bindings/GenericHashing.hs
+++ b/libsodium-bindings/src/LibSodium/Bindings/GenericHashing.hs
@@ -35,7 +35,7 @@ module LibSodium.Bindings.GenericHashing
 where
 
 import Foreign (Ptr, allocaBytes)
-import Foreign.C (CInt (..), CSize (..), CUChar (..), CULLong (..))
+import Foreign.C (CInt (CInt), CSize (CSize), CUChar, CULLong (CULLong))
 
 -- $introduction
 -- This API computes a fixed-length fingerprint for an arbitrarily long message.

--- a/libsodium-bindings/src/LibSodium/Bindings/PasswordHashing.hs
+++ b/libsodium-bindings/src/LibSodium/Bindings/PasswordHashing.hs
@@ -44,7 +44,7 @@ module LibSodium.Bindings.PasswordHashing
 where
 
 import Foreign (Ptr)
-import Foreign.C (CChar (..), CInt (..), CLLong (..), CSize (..), CUChar (..), CULLong (..))
+import Foreign.C (CChar, CInt (CInt), CLLong (CLLong), CSize (CSize), CUChar, CULLong (CULLong))
 
 -- $introduction
 -- This modules provides an API that can be used both for key derivation using a low-entropy input and password storage.

--- a/libsodium-bindings/src/LibSodium/Bindings/Secretbox.hs
+++ b/libsodium-bindings/src/LibSodium/Bindings/Secretbox.hs
@@ -35,7 +35,7 @@ module LibSodium.Bindings.Secretbox
 where
 
 import Foreign (Ptr)
-import Foreign.C (CChar (..), CInt (..), CSize (..), CUChar (..), CULLong (..))
+import Foreign.C (CChar, CInt (CInt), CSize (CSize), CUChar, CULLong (CULLong))
 
 -- $introduction
 -- This API allows encrypting a message using a secret key and a nonce.

--- a/sel/src/Sel/Hashing/Password.hs
+++ b/sel/src/Sel/Hashing/Password.hs
@@ -31,7 +31,7 @@ module Sel.Hashing.Password
   , genSalt
 
     -- * Argon2 Parameters
-  , Argon2Params (..)
+  , Argon2Params (Argon2Params)
   , defaultArgon2Params
   )
 where

--- a/sel/src/Sel/Internal.hs
+++ b/sel/src/Sel/Internal.hs
@@ -3,7 +3,7 @@
 
 module Sel.Internal where
 
-import Foreign.C.Types (CInt (..), CSize (..))
+import Foreign.C.Types (CInt (CInt), CSize (CSize))
 import Foreign.ForeignPtr (ForeignPtr, withForeignPtr)
 import Foreign.Ptr (Ptr)
 


### PR DESCRIPTION
(weirdly some imports need the constructor, whilst others do not)