### PR TITLE
Documentation overhaul

### DIFF
--- a/libsodium-bindings/libsodium-bindings.cabal
+++ b/libsodium-bindings/libsodium-bindings.cabal
@@ -20,8 +20,7 @@ extra-source-files:
   LICENSE
   README.md
 
-extra-doc-files:
-  CHANGELOG.md
+extra-doc-files:    CHANGELOG.md
 
 flag use-pkg-config
   description: Use pkg-config to find Libsodium (macOS and linux only).

--- a/libsodium-bindings/src/LibSodium/Bindings/AEAD.hs
+++ b/libsodium-bindings/src/LibSodium/Bindings/AEAD.hs
@@ -37,8 +37,8 @@ foreign import capi "sodium.h crypto_aead_xchacha20poly1305_ietf_encrypt"
     :: Ptr CUChar
     -- ^ Output buffer. Contains the encrypted message, authentication tag, and non-confidential additional data.
     -> Ptr CULLong
-    -- ^ Size of computed output. Should be message length plus crypto_aead_xchacha20poly1305_ietf_ABYTES.
-    -- If set to NULL, then no bytes will be written to this buffer.
+    -- ^ Size of computed output. Should be message length plus 'cryptoAEADXChaCha20Poly1305IETFABytes'.
+    -- If set to 'Foreign.Ptr.nullPtr', then no bytes will be written to this buffer.
     -> Ptr CUChar
     -- ^ Message to be encrypted.
     -> CULLong
@@ -49,12 +49,12 @@ foreign import capi "sodium.h crypto_aead_xchacha20poly1305_ietf_encrypt"
     -> CULLong
     -- ^ Additional data length.
     -> Ptr CUChar
-    -- ^ @nsec@, a parameter not used in this function. Should always be NULL.
+    -- ^ @nsec@, a parameter not used in this function. Should always be 'Foreign.Ptr.nullPtr'.
     -> Ptr CUChar
-    -- ^ Public nonce of size crypto_aead_xchacha20poly1305_ietf_NPUBBYTES.
-    -- Should never be reused with the same key. Nonces can be generated using randombytes_buf().
+    -- ^ Public nonce of size 'cryptoAEADXChaCha20Polt1305IETFPubBytes'.
+    -- Should never be reused with the same key. Nonces can be generated using 'LibSodium.Bindings.Random.randombytesBuf'.
     -> Ptr CUChar
-    -- ^ Secret key of size crypto_aead_xchacha20poly1305_ietf_KEYBYTES.
+    -- ^ Secret key of size 'cryptoAEADXChaCha20Poly1305IETFKeyBytes'.
     -> IO CInt
     -- ^ Returns -1 on failure, 0 on success.
 
@@ -66,12 +66,12 @@ foreign import capi "sodium.h crypto_aead_xchacha20poly1305_ietf_encrypt"
 foreign import capi "sodium.h crypto_aead_xchacha20poly1305_ietf_decrypt"
   cryptoAEADXChaCha20Poly1305IETFDecrypt
     :: Ptr CUChar
-    -- ^ Output buffer. At most, clen minus crypto_aead_xchacha20poly1305_ietf_ABYTES will be put into this.
+    -- ^ Output buffer. At most the cipher text length minus 'cryptoAEADXChaCha20Poly1305IETFABytes' will be put into this.
     -> Ptr CULLong
-    -- ^ Size of computed output. Should be message length plus crypto_aead_xchacha20poly1305_ietf_ABYTES.
-    -- If set to NULL, then no bytes will be written to this buffer.
+    -- ^ Size of computed output. Should be message length plus 'cryptoAEADXChaCha20Poly1305IETFABytes'.
+    -- If set to 'Foreign.Ptr.nullPtr', then no bytes will be written to this buffer.
     -> Ptr CUChar
-    -- ^ @nsec@, a parameter not used in this function. Should always be NULL.
+    -- ^ @nsec@, a parameter not used in this function. Should always be 'Foreign.Ptr.nullPtr'.
     -> Ptr CUChar
     -- ^ Ciphertext to decrypt.
     -> CULLong
@@ -82,10 +82,10 @@ foreign import capi "sodium.h crypto_aead_xchacha20poly1305_ietf_decrypt"
     -> CULLong
     -- ^ Additional data length.
     -> Ptr CUChar
-    -- ^ Public nonce of size crypto_aead_xchacha20poly1305_ietf_NPUBBYTES.
-    -- Should never be reused with the same key. Nonces can be generated using randombytes_buf().
+    -- ^ Public nonce of size 'cryptoAEADXChaCha20Polt1305IETFPubBytes'.
+    -- Should never be reused with the same key. Nonces can be generated using 'LibSodium.Bindings.Random.randombytesBuf'.
     -> Ptr CUChar
-    -- ^ Secret key of size crypto_aead_xchacha20poly1305_ietf_KEYBYTES.
+    -- ^ Secret key of size 'cryptoAEADXChaCha20Poly1305IETFKeyBytes'.
     -> IO CInt
     -- ^ Returns -1 on failure, 0 on success.
 
@@ -101,7 +101,7 @@ foreign import capi "sodium.h crypto_aead_xchacha20poly1305_ietf_encrypt_detache
     :: Ptr CUChar
     -- ^ Output buffer. Contains the encrypted message with length equal to the message.
     -> Ptr CUChar
-    -- ^ The authentication tag. Has length crypto_aead_xchacha20poly1305_ietf_ABYTES.
+    -- ^ The authentication tag. Has length 'cryptoAEADXChaCha20Poly1305IETFABytes'.
     -> Ptr CULLong
     -- ^ Length of the authentication tag buffer.
     -> Ptr CUChar
@@ -113,12 +113,12 @@ foreign import capi "sodium.h crypto_aead_xchacha20poly1305_ietf_encrypt_detache
     -> CULLong
     -- ^ Length of the additional, non-confidential data.
     -> Ptr CUChar
-    -- ^ Not used in this particular construction, should always be NULL.
+    -- ^ Not used in this particular construction, should always be 'Foreign.Ptr.nullPtr'.
     -> Ptr CUChar
-    -- ^ Public nonce of size crypto_aead_xchacha20poly1305_ietf_NPUBBYTES.
-    -- Should never be reused with the same key. Nonces can be generated using randombytes_buf().
+    -- ^ Public nonce of size 'cryptoAEADXChaCha20Polt1305IETFPubBytes'.
+    -- Should never be reused with the same key. Nonces can be generated using 'LibSodium.Bindings.Random.randombytesBuf'.
     -> Ptr CUChar
-    -- ^ Secret key of size crypto_aead_xchacha20poly1305_ietf_KEYBYTES.
+    -- ^ Secret key of size 'cryptoAEADXChaCha20Poly1305IETFKeyBytes'.
     -> IO CInt
     -- ^ Returns -1 on failure, 0 on success.
 
@@ -134,26 +134,26 @@ foreign import capi "sodium.h crypto_aead_xchacha20poly1305_ietf_decrypt_detache
     :: Ptr CUChar
     -- ^ If the tag is valid, the ciphertext is decrypted and put into this buffer.
     -> Ptr CUChar
-    -- ^ Not used in this particular construction, should always be NULL.
+    -- ^ Not used in this particular construction, should always be 'Foreign.Ptr.nullPtr'.
     -> Ptr CUChar
     -- ^ Ciphertext to be decrypted.
     -> CULLong
     -- ^ Length of the ciphertext.
     -> Ptr CUChar
-    -- ^ The authentication tag. Has length crypto_aead_xchacha20poly1305_ietf_ABYTES.
+    -- ^ The authentication tag. Has length 'cryptoAEADXChaCha20Poly1305IETFABytes'.
     -> Ptr CUChar
     -- ^ Additional, non-confidential data.
     -> CULLong
     -- ^ Length of the additional, non-confidential data.
     -> Ptr CUChar
-    -- ^ Public nonce of size crypto_aead_xchacha20poly1305_ietf_NPUBBYTES.
-    -- Should never be reused with the same key. Nonces can be generated using randombytes_buf().
+    -- ^ Public nonce of size 'cryptoAEADXChaCha20Polt1305IETFPubBytes'.
+    -- Should never be reused with the same key. Nonces can be generated using 'LibSodium.Bindings.Random.randombytesBuf'.
     -> Ptr CUChar
-    -- ^ Secret key of size crypto_aead_xchacha20poly1305_ietf_KEYBYTES.
+    -- ^ Secret key of size 'cryptoAEADXChaCha20Poly1305IETFKeyBytes'.
     -> IO CInt
     -- ^ Returns 0 on success, -1 if tag is not valid.
 
--- * Constants.
+-- == Constants.
 
 -- | Recommended length of a key for this construction.
 --

--- a/libsodium-bindings/src/LibSodium/Bindings/KeyDerivation.hs
+++ b/libsodium-bindings/src/LibSodium/Bindings/KeyDerivation.hs
@@ -27,12 +27,26 @@ where
 import Foreign (Ptr, Word64, Word8)
 import Foreign.C (CChar, CInt (CInt), CSize (CSize), CUChar)
 
+-- $introduction
+--
+-- From a single, high-entropy key, you can derive multiple secret sub-keys.
+--
+-- This API can derive up to 2⁶⁴ keys from a single key and context, and these
+-- sub-keys can have an arbitrary length between 128 (16 bytes) and 512 bits (64 bytes).
+
+-- | Generate a high-entropy key from which the sub-keys will be derived.
+--
+-- @since 0.0.1.0
 foreign import capi "sodium.h crypto_kdf_keygen"
   cryptoKDFKeygen
     :: Ptr Word8
     -- ^ Pointer that will hold the master key of length 'cryptoKDFKeyBytes'
     -> IO ()
 
+-- | Derive a sub-key from a high-entropy secre key with a unique identifier.
+-- The identifier can be any value up to 2⁶⁴-1
+--
+-- @since 0.0.1.0
 foreign import capi "sodium.h crypto_kdf_derive_from_key"
   cryptoKDFDeriveFromKey
     :: Ptr CUChar
@@ -49,9 +63,6 @@ foreign import capi "sodium.h crypto_kdf_derive_from_key"
     -- ^ Returns 0 on success and -1 on error.
 
 -- == Constants
-
---
--- @since 0.0.1.0
 
 -- | Minimum length of a sub-key.
 --

--- a/libsodium-bindings/src/LibSodium/Bindings/Scrypt.hs
+++ b/libsodium-bindings/src/LibSodium/Bindings/Scrypt.hs
@@ -278,7 +278,7 @@ foreign import capi "sodium.h value crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_
 -- ⚠️  using the sensitive parameters can take up to 2 seconds on a 2.8GHz Core i7 CPU
 -- and require up to 1GiB of dedicated RAM.
 --
--- | @since 0.0.1.0
+-- @since 0.0.1.0
 foreign import capi "sodium.h value crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_SENSITIVE"
   cryptoPWHashScryptSalsa2018SHA256OpsLimitSensitive :: CSize
 

--- a/libsodium-bindings/src/LibSodium/Bindings/SecureMemory.hs
+++ b/libsodium-bindings/src/LibSodium/Bindings/SecureMemory.hs
@@ -50,7 +50,7 @@ import Foreign.C.Types (CInt (CInt), CSize (CSize))
 -- On operating systems where this feature is implemented, kernel crash dumps
 -- should also be disabled.
 --
--- The 'lock' function wraps @mlock(2)@ and
+-- The 'sodiumMlock' function wraps @mlock(2)@ and
 -- [@VirtualLock()@](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtuallock).
 --
 -- Note: Many systems place limits on the amount of memory that may be locked

--- a/sel/sel.cabal
+++ b/sel/sel.cabal
@@ -18,8 +18,7 @@ extra-source-files:
   LICENSE
   README.md
 
-extra-doc-files:
-  CHANGELOG.md
+extra-doc-files:    CHANGELOG.md
 
 source-repository head
   type:     git
@@ -42,7 +41,7 @@ library
   import:          common
   hs-source-dirs:  src
   exposed-modules:
-    Sel.Hashing.Generic
+    Sel.Hashing
     Sel.Hashing.Password
     Sel.Hashing.SHA2
     Sel.Hashing.SHA2.SHA256
@@ -64,7 +63,7 @@ test-suite sel-tests
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
   other-modules:
-    Test.Hashing.Generic
+    Test.Hashing
     Test.Hashing.Password
     Test.Hashing.SHA2
     Test.Signing

--- a/sel/src/Sel/Hashing.hs
+++ b/sel/src/Sel/Hashing.hs
@@ -2,13 +2,13 @@
 
 -- |
 --
--- Module: Sel.Hashing.Generic
--- Description: Fingerprint hashing with the BLAKE2b algorithm
+-- Module: Sel.Hashing
+-- Description: Hashing with the BLAKE2b algorithm
 -- Copyright: (C) Hécate Moonlight 2022
 -- License: BSD-3-Clause
 -- Maintainer: The Haskell Cryptography Group
 -- Portability: GHC only
-module Sel.Hashing.Generic
+module Sel.Hashing
   ( -- * Introduction
     -- $introduction
 
@@ -28,7 +28,6 @@ import Data.ByteString (StrictByteString)
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Internal as BS
 
--- import qualified Data.ByteString.Unsafe as BS
 import Data.ByteString.Unsafe (unsafeUseAsCStringLen)
 import Data.Text (Text)
 import Data.Text.Display
@@ -45,14 +44,14 @@ import System.IO.Unsafe (unsafeDupablePerformIO)
 -- $introduction
 --
 -- This API computes a fixed-length fingerprint for an arbitrarily long message.
--- It is backed by the BLAKE2b algorithm.
+-- It is backed by the [BLAKE2b](https://en.wikipedia.org/wiki/BLAKE_\(hash_function\)) algorithm.
 --
 -- Sample use cases:
 --
 --   * File integrity checking
 --   * Creating unique identifiers to index arbitrarily long data
 --
--- __⚠️ Do not use this module to hash passwords! ⚠️__
+-- __⚠️ Do not use this module to hash passwords! ⚠️__ Please use the "Sel.Hashing.Password" module instead.
 --
 -- If you need to deviate from the defaults enforced by this module,
 -- please use the underlying bindings at "LibSodium.Bindings.GenericHashing".

--- a/sel/src/Sel/Hashing/Password.hs
+++ b/sel/src/Sel/Hashing/Password.hs
@@ -54,7 +54,7 @@ import LibSodium.Bindings.Random
 
 -- $introduction
 --
--- This API provides functions for password hashing, backed by the Argon2id algorithm.
+-- This API provides functions for password hashing, backed by the [Argon2id](https://en.wikipedia.org/wiki/Argon2) algorithm.
 --
 -- If you need to deviate from the defaults enforced by this module,
 -- please use the underlying bindings at "LibSodium.Bindings.PasswordHashing".
@@ -149,7 +149,7 @@ passwordHashToByteString (PasswordHash fPtr) =
   where
     hashBytesSize = fromIntegral @CSize @Int cryptoPWHashStrBytes
 
--- | Convert a 'PasswordHash' to a 'Text.
+-- | Convert a 'PasswordHash' to a 'Text'.
 --
 -- @since 0.0.1.0
 passwordHashToText :: PasswordHash -> Text

--- a/sel/src/Sel/Hashing/SHA2.hs
+++ b/sel/src/Sel/Hashing/SHA2.hs
@@ -32,7 +32,7 @@ import Sel.Hashing.SHA2.SHA512
 --
 -- The SHA-2 family of hashing functions is only provided for interoperability with other applications.
 --
--- If you are looking for a generic hash function, do use 'Sel.Hashing.Generic'.
+-- If you are looking for a generic hash function, do use 'Sel.Hashing'.
 --
 -- If you are looking to hash passwords or deriving keys from passwords, do use 'Sel.Hashing.Password',
 -- as the functions of the SHA-2 family are not suitable for this task.

--- a/sel/src/Sel/Hashing/SHA2/SHA256.hs
+++ b/sel/src/Sel/Hashing/SHA2/SHA256.hs
@@ -51,7 +51,7 @@ import Sel.Internal
 --
 -- The SHA-2 family of hashing functions is only provided for interoperability with other applications.
 --
--- If you are looking for a generic hash function, do use 'Sel.Hashing.Generic'.
+-- If you are looking for a generic hash function, do use 'Sel.Hashing'.
 --
 -- If you are looking to hash passwords or deriving keys from passwords, do use 'Sel.Hashing.Password',
 -- as the functions of the SHA-2 family are not suitable for this task.

--- a/sel/src/Sel/Hashing/SHA2/SHA512.hs
+++ b/sel/src/Sel/Hashing/SHA2/SHA512.hs
@@ -54,7 +54,7 @@ import Sel.Internal
 --
 -- The SHA-2 family of hashing functions is only provided for interoperability with other applications.
 --
--- If you are looking for a generic hash function, do use 'Sel.Hashing.Generic'.
+-- If you are looking for a generic hash function, do use 'Sel.Hashing'.
 --
 -- If you are looking to hash passwords or deriving keys from passwords, do use 'Sel.Hashing.Password',
 -- as the functions of the SHA-2 family are not suitable for this task.

--- a/sel/test/Main.hs
+++ b/sel/test/Main.hs
@@ -3,7 +3,7 @@ module Main where
 import Test.Tasty
 
 import LibSodium.Bindings.Main (sodiumInit)
-import qualified Test.Hashing.Generic as Generic
+import qualified Test.Hashing as Hashing
 import qualified Test.Hashing.Password as Password
 import qualified Test.Hashing.SHA2 as SHA2
 import qualified Test.Signing as Signing
@@ -15,7 +15,7 @@ main = do
 
 specs :: [TestTree]
 specs =
-  [ Generic.spec
+  [ Hashing.spec
   , Password.spec
   , Signing.spec
   , SHA2.spec

--- a/sel/test/Test/Hashing.hs
+++ b/sel/test/Test/Hashing.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Test.Hashing.Generic where
+module Test.Hashing where
 
 import Control.Monad (void)
 
@@ -10,7 +10,7 @@ import qualified Data.ByteString.Unsafe as BS
 import Foreign hiding (void)
 import Foreign.C
 import LibSodium.Bindings.GenericHashing (cryptoGenericHash, cryptoGenericHashBytes)
-import Sel.Hashing.Generic
+import Sel.Hashing
 import Test.Tasty
 import Test.Tasty.HUnit
 


### PR DESCRIPTION
* fixes #70 
* Use `StrictByteString` everywhere
* Put the blake2b hashing in Sel.Hashing, drop the .Generic module as it is very confusing for Haskellers.