### PR TITLE
[feat] automatically finalise Hashing within `withMultiPart`

### DIFF
--- a/sel/src/Sel/Hashing/SHA2.hs
+++ b/sel/src/Sel/Hashing/SHA2.hs
@@ -23,7 +23,6 @@ module Sel.Hashing.SHA2
   , Multipart
   , withMultipart
   , updateMultipart
-  , finaliseMultipart
   ) where
 
 import Sel.Hashing.SHA2.SHA512

--- a/sel/test/Test/Hashing/SHA2.hs
+++ b/sel/test/Test/Hashing/SHA2.hs
@@ -32,7 +32,6 @@ testMultipartHashSH512 = do
   actual <- SHA512.withMultipart $ \multipart -> do
     SHA512.updateMultipart multipart "hunter"
     SHA512.updateMultipart multipart "2"
-    SHA512.finaliseMultipart multipart
   assertEqual
     "SHA512 hashing is consistent"
     (SHA512.hashToHexByteString actual)
@@ -52,7 +51,6 @@ testMultipartHashSH256 = do
   actual <- SHA256.withMultipart $ \multipart -> do
     SHA256.updateMultipart multipart "hunter"
     SHA256.updateMultipart multipart "2"
-    SHA256.finaliseMultipart multipart
   assertEqual
     "SHA256 hashing is consistent"
     (SHA256.hashToHexByteString actual)


### PR DESCRIPTION
- this removes `finaliseMultipart` from the API of `sel` because it can be automatically called from within `withMultipart`
- this solves two issues
  1. within `withMultipart` the user could call the finalizer more than once 
  2. the user could forget to call `finaliseMultipart` 
- it seems to me that this is the only correct usage of the function, if that's not the case, perhaps this PR is not complete and I should re-expose the function