### PR TITLE
Add salt conversion functions

### DIFF
--- a/sel/test/Test/Hashing/Password.hs
+++ b/sel/test/Test/Hashing/Password.hs
@@ -2,6 +2,8 @@
 
 module Test.Hashing.Password where
 
+import Data.Function (on)
+import Data.Maybe (isNothing)
 import Data.Text (Text)
 import qualified Sel.Hashing.Password as Sel
 import Test.Tasty
@@ -11,7 +13,8 @@ spec :: TestTree
 spec =
   testGroup
     "Password hashing tests"
-    [ testCase "Round-trip test for password hashing with random salt" testHashPassword
+    [ testCase "Round-trip test for password hashing" testHashPassword
+    , testCase "Consistent password hashing with salt" testHashPasswordWSalt
     ]
 
 testHashPassword :: Assertion
@@ -21,3 +24,31 @@ testHashPassword = do
   assertBool
     "Password hashing is consistent"
     (Sel.verifyText passwordHash "hunter2")
+
+testHashPasswordWSalt :: Assertion
+testHashPasswordWSalt = do
+  let hashWSalt s = Sel.hashByteStringWithParams Sel.defaultArgon2Params s
+      password = "hunter2"
+      cmpPWHashes = on (==) Sel.passwordHashToByteString
+
+  salt1 <- Sel.genSalt
+  hashOrig <- hashWSalt salt1 password
+  hashOrig' <- hashWSalt salt1 password
+  assertBool
+    "Password hashing with salt is consistent"
+    (cmpPWHashes hashOrig hashOrig')
+
+  hashWoSalt <- Sel.hashByteString password
+  assertBool
+    "Password hashing with salt differs from without"
+    (not $ cmpPWHashes hashOrig hashWoSalt)
+
+  salt2 <- Sel.genSalt
+  hashWNewSalt <- hashWSalt salt2 password
+  assertBool
+    "Password hashing differs with a new salt"
+    (not $ cmpPWHashes hashOrig hashWNewSalt)
+
+  assertBool
+    "Bogus salt ByteString fails to generate Salt"
+    (isNothing (Sel.byteStringToSalt "deadbeef"))


### PR DESCRIPTION
Salts often need to be stored alongside passwords so the opaque representation needs a way of being converted to something we can deal with. Constructing salts checks the 'StrictByteString' is the right length.

While reading `ByteString` documentation I also realised that `genSalt` could be much more neatly implemented using `create`, and I added a bunch of tests for using the `hashByteStringWithParams`.