### PR TITLE
Add more conversion functions for PasswordHash

### DIFF
--- a/sel/src/Sel/Hashing/SHA2/SHA256.hs
+++ b/sel/src/Sel/Hashing/SHA2/SHA256.hs
@@ -198,8 +198,6 @@ type role Multipart nominal
 -- The context is safely allocated first, then the continuation is run
 -- and then it is deallocated after that.
 --
--- Do not try to jailbreak the context outside of the action, this will not be pleasant.
---
 -- @since 0.0.1.0
 withMultipart
   :: forall (a :: Type) (m :: Type -> Type)

--- a/sel/src/Sel/Hashing/SHA2/SHA512.hs
+++ b/sel/src/Sel/Hashing/SHA2/SHA512.hs
@@ -189,8 +189,6 @@ type role Multipart nominal
 --
 -- The context is safely allocated and deallocated inside of the continuation.
 --
--- Do not try to jailbreak the context outside of the action, this will not be pleasant.
---
 -- @since 0.0.1.0
 withMultipart
   :: forall (a :: Type) (m :: Type -> Type)

--- a/sel/test/Test/Hashing/Password.hs
+++ b/sel/test/Test/Hashing/Password.hs
@@ -13,23 +13,30 @@ spec :: TestTree
 spec =
   testGroup
     "Password hashing tests"
-    [ testCase "Round-trip test for password hashing" testHashPassword
+    [ testCase "Round-trip test for password hashing" testRoundtripHash
     , testCase "Consistent password hashing with salt" testHashPasswordWSalt
     ]
 
-testHashPassword :: Assertion
-testHashPassword = do
+testRoundtripHash :: Assertion
+testRoundtripHash = do
   let password = "hunter2" :: Text
   passwordHash <- Sel.hashText password
+  let textualHash = Sel.passwordHashToByteString passwordHash
+  let passwordHash' = Sel.asciiByteStringToPasswordHash textualHash
+
   assertBool
     "Password hashing is consistent"
     (Sel.verifyText passwordHash "hunter2")
+
+  assertBool
+    "Password hashing is consistent"
+    (Sel.verifyText passwordHash' "hunter2")
 
 testHashPasswordWSalt :: Assertion
 testHashPasswordWSalt = do
   let hashWSalt s = Sel.hashByteStringWithParams Sel.defaultArgon2Params s
       password = "hunter2"
-      cmpPWHashes = on (==) Sel.passwordHashToHexByteString
+      cmpPWHashes = on (==) Sel.passwordHashToByteString
 
   salt1 <- Sel.genSalt
   hashOrig <- hashWSalt salt1 password


### PR DESCRIPTION
The following functions are added:

* `asciiTextToPasswordHash`
* `asciiByteStringToPasswordHash`


The idea is that there is this password ASCII format that looks like this:

`$argon2id$v=19$m=262144,t=3,p=1$fpPdXj9mK7J4m…`

Password hashes are created by `hashByteString` in this format.

Keys that are derived with `hashByteStringWithParams` are not stored like this. It's a binary format that needs base16 encoding. I think I'm not too comfortable with this, we should probably implement the ASCII format for the output of this function.