### PR TITLE
Remove manual freeing functions from Sel

### DIFF
--- a/sel/src/Sel/HMAC/SHA256.hs
+++ b/sel/src/Sel/HMAC/SHA256.hs
@@ -39,7 +39,6 @@ module Sel.HMAC.SHA256
   , newAuthenticationKey
   , authenticationKeyFromHexByteString
   , unsafeAuthenticationKeyToHexByteString
-  , freeAuthenticationKey
 
     -- ** Authentication tag
   , AuthenticationTag
@@ -269,10 +268,7 @@ newAuthenticationKey = newAuthenticationKeyWith cryptoAuthHMACSHA256Keygen
 --
 -- Memory is allocated with 'LibSodium.Bindings.SecureMemory.sodiumMalloc'
 -- (see the note attached there).
--- Finalizer is run when the key is goes out of scope, but 'freeAuthenticationKey'
--- can be used to release early.
---
--- @since 0.0.1.0
+-- A finalizer is run when the key is goes out of scope.
 newAuthenticationKeyWith :: (Foreign.Ptr CUChar -> IO ()) -> IO AuthenticationKey
 newAuthenticationKeyWith action = do
   ptr <- sodiumMalloc cryptoAuthHMACSHA256Bytes
@@ -283,14 +279,6 @@ newAuthenticationKeyWith action = do
   Foreign.addForeignPtrFinalizer finalizerSodiumFree fPtr
   action ptr
   pure $ AuthenticationKey fPtr
-
--- | Trigger memory clean up and release without waiting for GC.
---
--- The 'AuthenticationKey' must not be used again.
---
--- @since 0.0.1.0
-freeAuthenticationKey :: AuthenticationKey -> IO ()
-freeAuthenticationKey (AuthenticationKey fPtr) = Foreign.finalizeForeignPtr fPtr
 
 -- | Create an 'AuthenticationKey' from a binary 'StrictByteString' that you have obtained on your own,
 -- usually from the network or disk.

--- a/sel/src/Sel/HMAC/SHA512.hs
+++ b/sel/src/Sel/HMAC/SHA512.hs
@@ -39,7 +39,6 @@ module Sel.HMAC.SHA512
   , newAuthenticationKey
   , authenticationKeyFromHexByteString
   , unsafeAuthenticationKeyToHexByteString
-  , freeAuthenticationKey
 
     -- ** Authentication tag
   , AuthenticationTag
@@ -269,10 +268,7 @@ newAuthenticationKey = newAuthenticationKeyWith cryptoAuthHMACSHA512Keygen
 --
 -- Memory is allocated with 'LibSodium.Bindings.SecureMemory.sodiumMalloc'
 -- (see the note attached there).
--- Finalizer is run when the key is goes out of scope, but 'freeAuthenticationKey'
--- can be used to release early.
---
--- @since 0.0.1.0
+-- A finalizer is run when the key is goes out of scope.
 newAuthenticationKeyWith :: (Foreign.Ptr CUChar -> IO ()) -> IO AuthenticationKey
 newAuthenticationKeyWith action = do
   ptr <- sodiumMalloc cryptoAuthHMACSHA512Bytes
@@ -283,14 +279,6 @@ newAuthenticationKeyWith action = do
   Foreign.addForeignPtrFinalizer finalizerSodiumFree fPtr
   action ptr
   pure $ AuthenticationKey fPtr
-
--- | Trigger memory clean up and release without waiting for GC.
---
--- The 'AuthenticationKey' must not be used again.
---
--- @since 0.0.1.0
-freeAuthenticationKey :: AuthenticationKey -> IO ()
-freeAuthenticationKey (AuthenticationKey fPtr) = Foreign.finalizeForeignPtr fPtr
 
 -- | Create an 'AuthenticationKey' from a binary 'StrictByteString' that you have obtained on your own,
 -- usually from the network or disk.

--- a/sel/src/Sel/HMAC/SHA512_256.hs
+++ b/sel/src/Sel/HMAC/SHA512_256.hs
@@ -37,7 +37,6 @@ module Sel.HMAC.SHA512_256
   , newAuthenticationKey
   , authenticationKeyFromHexByteString
   , unsafeAuthenticationKeyToHexByteString
-  , freeAuthenticationKey
 
     -- ** Authentication tag
   , AuthenticationTag
@@ -267,10 +266,7 @@ newAuthenticationKey = newAuthenticationKeyWith cryptoAuthHMACSHA512256Keygen
 --
 -- Memory is allocated with 'LibSodium.Bindings.SecureMemory.sodiumMalloc'
 -- (see the note attached there).
--- Finalizer is run when the key is goes out of scope, but 'freeAuthenticationKey'
--- can be used to release early.
---
--- @since 0.0.1.0
+-- A finalizer is run when the key is goes out of scope.
 newAuthenticationKeyWith :: (Foreign.Ptr CUChar -> IO ()) -> IO AuthenticationKey
 newAuthenticationKeyWith action = do
   ptr <- sodiumMalloc cryptoAuthHMACSHA512256Bytes
@@ -281,14 +277,6 @@ newAuthenticationKeyWith action = do
   Foreign.addForeignPtrFinalizer finalizerSodiumFree fPtr
   action ptr
   pure $ AuthenticationKey fPtr
-
--- | Trigger memory clean up and release without waiting for GC.
---
--- The 'AuthenticationKey' must not be used again.
---
--- @since 0.0.1.0
-freeAuthenticationKey :: AuthenticationKey -> IO ()
-freeAuthenticationKey (AuthenticationKey fPtr) = Foreign.finalizeForeignPtr fPtr
 
 -- | Create an 'AuthenticationKey' from a binary 'StrictByteString' that you have obtained on your own,
 -- usually from the network or disk.

--- a/sel/src/Sel/PublicKey/Cipher.hs
+++ b/sel/src/Sel/PublicKey/Cipher.hs
@@ -24,7 +24,6 @@ module Sel.PublicKey.Cipher
     newKeyPair
   , SecretKey (..)
   , unsafeSecretKeyToHexByteString
-  , freeSecretKey
   , PublicKey (..)
   , publicKeyToHexByteString
   , keyPairFromHexByteStrings
@@ -226,10 +225,7 @@ keyPairFromHexByteStrings publicByteStringHex secretByteStringHex =
 --
 -- Memory is allocated with 'LibSodium.Bindings.SecureMemory.sodiumMalloc'
 -- (see the note attached there).
--- Finalizer is run when the key is goes out of scope, but 'freeSecretKey'
--- can be used to release early.
---
--- @since 0.0.1.0
+-- A finalizer is run when the key is goes out of scope.
 newKeyPairWith
   :: ( Ptr CUChar
        -- \^ Public Key pointer
@@ -253,14 +249,6 @@ newKeyPairWith action = do
 
   action publicKeyPtr secretKeyPtr
   pure (PublicKey publicKeyForeignPtr, SecretKey secretKeyForeignPtr)
-
--- | Trigger memory clean up and release without waiting for GC.
---
--- The 'SecretKey' must not be used again.
---
--- @since 0.0.1.0
-freeSecretKey :: SecretKey -> IO ()
-freeSecretKey (SecretKey fPtr) = Foreign.finalizeForeignPtr fPtr
 
 -- | Convert a 'SecretKey' to a hexadecimal-encoded 'StrictByteString'.
 --

--- a/sel/src/Sel/SecretKey/Authentication.hs
+++ b/sel/src/Sel/SecretKey/Authentication.hs
@@ -25,7 +25,6 @@ module Sel.SecretKey.Authentication
   , newAuthenticationKey
   , authenticationKeyFromHexByteString
   , unsafeAuthenticationKeyToHexByteString
-  , freeAuthenticationKey
 
     -- ** Authentication tag
   , AuthenticationTag
@@ -172,10 +171,7 @@ newAuthenticationKey = newAuthenticationKeyWith cryptoAuthKeygen
 --
 -- Memory is allocated with 'LibSodium.Bindings.SecureMemory.sodiumMalloc'
 -- (see the note attached there).
--- Finalizer is run when the key is goes out of scope, but 'freeAuthenticationKey'
--- can be used to release early.
---
--- @since 0.0.1.0
+-- A finalizer is run when the key is goes out of scope.
 newAuthenticationKeyWith :: (Foreign.Ptr CUChar -> IO ()) -> IO AuthenticationKey
 newAuthenticationKeyWith action = do
   ptr <- sodiumMalloc cryptoAuthKeyBytes
@@ -186,14 +182,6 @@ newAuthenticationKeyWith action = do
   Foreign.addForeignPtrFinalizer finalizerSodiumFree fPtr
   action ptr
   pure $ AuthenticationKey fPtr
-
--- | Trigger memory clean up and release without waiting for GC.
---
--- The 'AuthenticationKey' must not be used again.
---
--- @since 0.0.1.0
-freeAuthenticationKey :: AuthenticationKey -> IO ()
-freeAuthenticationKey (AuthenticationKey fPtr) = Foreign.finalizeForeignPtr fPtr
 
 -- | Create an 'AuthenticationKey' from a binary 'StrictByteString' that you have obtained on your own,
 -- usually from the network or disk.

--- a/sel/src/Sel/SecretKey/Cipher.hs
+++ b/sel/src/Sel/SecretKey/Cipher.hs
@@ -28,8 +28,6 @@ module Sel.SecretKey.Cipher
   , newSecretKey
   , secretKeyFromHexByteString
   , unsafeSecretKeyToHexByteString
-  , newSecretKeyWith
-  , freeSecretKey
 
     -- ** Nonce
   , Nonce
@@ -159,7 +157,7 @@ secretKeyFromHexByteString hexNonce = unsafeDupablePerformIO $
 -- | Prepare memory for a 'SecretKey' and use the provided action to fill it.
 --
 -- Memory is allocated with 'LibSodium.Bindings.SecureMemory.sodiumMalloc' (see the note attached there).
--- Finalizer is run when the key is goes out of scope, but 'freeSecretKey' can be used to release early.
+-- A finalizer is run when the key is goes out of scope.
 --
 -- @since 0.0.1.0
 newSecretKeyWith :: (Foreign.Ptr CUChar -> IO ()) -> IO SecretKey
@@ -172,14 +170,6 @@ newSecretKeyWith action = do
   Foreign.addForeignPtrFinalizer finalizerSodiumFree fPtr
   action ptr
   pure $ SecretKey fPtr
-
--- | Trigger memory clean up and release without waiting for GC.
---
--- The 'SecretKey' must not be used again.
---
--- @since 0.0.1.0
-freeSecretKey :: SecretKey -> IO ()
-freeSecretKey (SecretKey fPtr) = Foreign.finalizeForeignPtr fPtr
 
 -- | Convert a 'SecretKey' to a hexadecimal-encoded 'StrictByteString'.
 --


### PR DESCRIPTION
This PR removes low-level deallocation functions from the high-level API.