### PR TITLE
Correct terminology for HMAC-SHA2 and add toBinary function

### DIFF
--- a/sel/src/Sel/HMAC/SHA256.hs
+++ b/sel/src/Sel/HMAC/SHA256.hs
@@ -23,10 +23,10 @@ module Sel.HMAC.SHA256
 
     -- ** Operations
 
-    -- *** Hashing a single messsage
+    -- *** Authenticating a single messsage
     authenticate
 
-    -- *** Hashing a multi-part message
+    -- *** Authenicating a multi-part message
   , Multipart
   , withMultipart
   , updateMultipart
@@ -43,6 +43,7 @@ module Sel.HMAC.SHA256
     -- ** Authentication tag
   , AuthenticationTag
   , authenticationTagToHexByteString
+  , authenticationTagToBinary
   , authenticationTagFromHexByteString
   ) where
 
@@ -131,7 +132,7 @@ authenticate message (AuthenticationKey authenticationKeyForeignPtr) =
             authKeyPtr
     pure $ AuthenticationTag authenticationTagForeignPtr
 
--- ** Hashing a multi-part message
+-- ** Authenicating a multi-part message
 
 -- | 'Multipart' is a cryptographic context for streaming hashing.
 -- This API can be used when a message is too big to fit
@@ -140,11 +141,11 @@ authenticate message (AuthenticationKey authenticationKeyForeignPtr) =
 -- Use it like this:
 --
 -- >>> secretKey <- HMAC.newSecreKey
--- >>> hash <- Hashing.withMultipart secretKey $ \multipartState -> do -- we are in MonadIO
+-- >>> hash <- HMAC.withMultipart secretKey $ \multipartState -> do -- we are in MonadIO
 -- ...   message1 <- getMessage
--- ...   Hashing.updateMultipart multipartState message1
+-- ...   HMAC.updateMultipart multipartState message1
 -- ...   message2 <- getMessage
--- ...   Hashing.updateMultipart multipartState message2
+-- ...   HMAC.updateMultipart multipartState message2
 --
 -- @since 0.0.1.0
 newtype Multipart s = Multipart (Ptr CryptoAuthHMACSHA256State)
@@ -174,7 +175,7 @@ withMultipart (AuthenticationKey secretKeyForeignPtr) actions = do
     actions part
     finaliseMultipart part
 
--- | Compute the 'Hash' of all the portions that were fed to the cryptographic context.
+-- | Compute the 'AuthenticationTag' of all the portions that were fed to the cryptographic context.
 --
 --  this function is only used within 'withMultipart'
 --
@@ -350,12 +351,19 @@ instance Show AuthenticationTag where
 --
 -- @since 0.0.1.0
 authenticationTagToHexByteString :: AuthenticationTag -> StrictByteString
-authenticationTagToHexByteString (AuthenticationTag fPtr) =
+authenticationTagToHexByteString authenticationTag =
   Base16.extractBase16 $
     Base16.encodeBase16' $
-      BS.fromForeignPtr0
-        (Foreign.castForeignPtr fPtr)
-        (fromIntegral cryptoAuthHMACSHA256Bytes)
+      authenticationTagToBinary authenticationTag
+
+-- | Convert an 'AuthenticationTag' to a binary 'StrictByteString'.
+--
+-- @since 0.0.1.0
+authenticationTagToBinary :: AuthenticationTag -> StrictByteString
+authenticationTagToBinary (AuthenticationTag fPtr) =
+  BS.fromForeignPtr0
+    (Foreign.castForeignPtr fPtr)
+    (fromIntegral cryptoAuthHMACSHA256Bytes)
 
 -- | Create an 'AuthenticationTag' from a binary 'StrictByteString' that you have obtained on your own,
 -- usually from the network or disk.
@@ -378,5 +386,5 @@ authenticationTagFromHexByteString hexTag = unsafeDupablePerformIO $
             Right $
               AuthenticationTag
                 (Foreign.castForeignPtr @CChar @CUChar hashForeignPtr)
-        else pure $ Left $ Text.pack "Hash is too short"
+        else pure $ Left $ Text.pack "Authenticationg tag is too short"
     Left msg -> pure $ Left msg

--- a/sel/src/Sel/HMAC/SHA512.hs
+++ b/sel/src/Sel/HMAC/SHA512.hs
@@ -23,10 +23,10 @@ module Sel.HMAC.SHA512
 
     -- ** Operations
 
-    -- *** Hashing a single messsage
+    -- *** Authenticating a single messsage
     authenticate
 
-    -- *** Hashing a multi-part message
+    -- *** Authenticating a multi-part message
   , Multipart
   , withMultipart
   , updateMultipart
@@ -43,6 +43,7 @@ module Sel.HMAC.SHA512
     -- ** Authentication tag
   , AuthenticationTag
   , authenticationTagToHexByteString
+  , authenticationTagToBinary
   , authenticationTagFromHexByteString
   ) where
 
@@ -131,7 +132,7 @@ authenticate message (AuthenticationKey authenticationKeyForeignPtr) =
             authKeyPtr
     pure $ AuthenticationTag authenticationTagForeignPtr
 
--- ** Hashing a multi-part message
+-- ** Authenticating a multi-part message
 
 -- | 'Multipart' is a cryptographic context for streaming hashing.
 -- This API can be used when a message is too big to fit
@@ -140,11 +141,11 @@ authenticate message (AuthenticationKey authenticationKeyForeignPtr) =
 -- Use it like this:
 --
 -- >>> secretKey <- HMAC.newSecreKey
--- >>> hash <- Hashing.withMultipart secretKey $ \multipartState -> do -- we are in MonadIO
+-- >>> hash <- HMAC.withMultipart secretKey $ \multipartState -> do -- we are in MonadIO
 -- ...   message1 <- getMessage
--- ...   Hashing.updateMultipart multipartState message1
+-- ...   HMAC.updateMultipart multipartState message1
 -- ...   message2 <- getMessage
--- ...   Hashing.updateMultipart multipartState message2
+-- ...   HMAC.updateMultipart multipartState message2
 --
 -- @since 0.0.1.0
 newtype Multipart s = Multipart (Ptr CryptoAuthHMACSHA512State)
@@ -174,7 +175,7 @@ withMultipart (AuthenticationKey secretKeyForeignPtr) actions = do
     actions part
     finaliseMultipart part
 
--- | Compute the 'Hash' of all the portions that were fed to the cryptographic context.
+-- | Compute the 'AuthenticationTag' of all the portions that were fed to the cryptographic context.
 --
 --  this function is only used within 'withMultipart'
 --
@@ -350,12 +351,19 @@ instance Show AuthenticationTag where
 --
 -- @since 0.0.1.0
 authenticationTagToHexByteString :: AuthenticationTag -> StrictByteString
-authenticationTagToHexByteString (AuthenticationTag fPtr) =
+authenticationTagToHexByteString authenticationTag =
   Base16.extractBase16 $
     Base16.encodeBase16' $
-      BS.fromForeignPtr0
-        (Foreign.castForeignPtr fPtr)
-        (fromIntegral cryptoAuthHMACSHA512Bytes)
+      authenticationTagToBinary authenticationTag
+
+-- | Convert an 'AuthenticationTag' to a binary 'StrictByteString'.
+--
+-- @since 0.0.1.0
+authenticationTagToBinary :: AuthenticationTag -> StrictByteString
+authenticationTagToBinary (AuthenticationTag fPtr) =
+  BS.fromForeignPtr0
+    (Foreign.castForeignPtr fPtr)
+    (fromIntegral cryptoAuthHMACSHA512Bytes)
 
 -- | Create an 'AuthenticationTag' from a binary 'StrictByteString' that you have obtained on your own,
 -- usually from the network or disk.
@@ -378,5 +386,5 @@ authenticationTagFromHexByteString hexTag = unsafeDupablePerformIO $
             Right $
               AuthenticationTag
                 (Foreign.castForeignPtr @CChar @CUChar hashForeignPtr)
-        else pure $ Left $ Text.pack "Hash is too short"
+        else pure $ Left $ Text.pack "Authentication tag is too short"
     Left msg -> pure $ Left msg

--- a/sel/src/Sel/Internal.hs
+++ b/sel/src/Sel/Internal.hs
@@ -40,9 +40,9 @@ foreignPtrOrd fptr1 fptr2 size =
         result <- memcmp p q size
         return $
           if
-              | result == 0 -> EQ
-              | result < 0 -> LT
-              | otherwise -> GT
+            | result == 0 -> EQ
+            | result < 0 -> LT
+            | otherwise -> GT
 
 foreignPtrShow :: ForeignPtr a -> CSize -> String
 foreignPtrShow fptr size =

--- a/sel/src/Sel/Internal.hs
+++ b/sel/src/Sel/Internal.hs
@@ -40,9 +40,9 @@ foreignPtrOrd fptr1 fptr2 size =
         result <- memcmp p q size
         return $
           if
-            | result == 0 -> EQ
-            | result < 0 -> LT
-            | otherwise -> GT
+              | result == 0 -> EQ
+              | result < 0 -> LT
+              | otherwise -> GT
 
 foreignPtrShow :: ForeignPtr a -> CSize -> String
 foreignPtrShow fptr size =


### PR DESCRIPTION
This PR replaces instances of "Hash" with "Authenticate" in the HMAC modules, and adds `authenticationTagToBinary` conversion functions.