### PR TITLE
fix: use current GHC in flake (#131)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,7 +13,7 @@ jobs:
 
     - uses: haskell-actions/run-fourmolu@v9
       with:
-        version: "0.12.0.0"
+        version: "0.14.0.0"
         pattern: |
           sel/**/*.hs
           libsodium-bindings/**/*.hs

--- a/flake.lock
+++ b/flake.lock
@@ -105,11 +105,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685894048,
-        "narHash": "sha256-QKqv1QS+22k9oxncj1AnAxeqS5jGnQiUW3Jq3B+dI1w=",
+        "lastModified": 1701693815,
+        "narHash": "sha256-7BkrXykVWfkn6+c1EhFA3ko4MLi3gVG0p9G96PNnKTM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2e56a850786211972d99d2bb39665a9b5a1801d6",
+        "rev": "09ec6a0881e1a36c29d67497693a67a16f4da573",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,8 +41,6 @@
       let
         inherit (inputs.gitignore.lib) gitignoreSource;
 
-        ghcVer = "945";
-
         pkgs = nixpkgs.legacyPackages.${system};
 
         pre-commit-check = inputs.pre-commit-hooks.lib.${system}.run {
@@ -60,7 +58,7 @@
           };
         };
 
-        hsPkgs = pkgs.haskell.packages."ghc${ghcVer}".override (_old: {
+        hsPkgs = pkgs.haskellPackages.override (_old: {
           overrides = with pkgs.haskell.lib.compose; hself: hsuper:
             let
               commonOverrides = overrideCabal (_drv: {
@@ -99,7 +97,7 @@
             haskell-language-server
             hlint
             cabal-fmt
-            fourmolu_0_12_0_0
+            fourmolu
           ];
         };
 

--- a/sel/src/Sel/Internal.hs
+++ b/sel/src/Sel/Internal.hs
@@ -40,9 +40,9 @@ foreignPtrOrd fptr1 fptr2 size =
         result <- memcmp p q size
         return $
           if
-              | result == 0 -> EQ
-              | result < 0 -> LT
-              | otherwise -> GT
+            | result == 0 -> EQ
+            | result < 0 -> LT
+            | otherwise -> GT
 
 foreignPtrShow :: ForeignPtr a -> CSize -> String
 foreignPtrShow fptr size =


### PR DESCRIPTION
Users would then be able to change `inputs.nixpkgs` and select the right version.

Alternatively I can define one attribute per version.

Let me know what you think.