### PR TITLE
Better implementation of password hash import/export

### DIFF
--- a/.github/workflows/libsodium-bindings.yml
+++ b/.github/workflows/libsodium-bindings.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Configure
         run: |
           ./.github/workflows/install-libsodium.sh
-          cabal freeze
       - name: Cache
         uses: actions/cache@v3.3.2
         with:

--- a/.github/workflows/libsodium-bindings.yml
+++ b/.github/workflows/libsodium-bindings.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           cabal-file: libsodium-bindings/libsodium-bindings.cabal
           ubuntu: true
+          macos: true
           version: 0.1.6.0
   tests:
     name: ${{ matrix.ghc }} on ${{ matrix.os }}

--- a/.github/workflows/libsodium-bindings.yml
+++ b/.github/workflows/libsodium-bindings.yml
@@ -13,14 +13,13 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - name: Checkout base repo
-        uses: actions/checkout@v4
       - name: Extract the tested GHC versions
         id: set-matrix
-        run: |
-          wget https://github.com/Kleidukos/get-tested/releases/download/v0.1.4.0/get-tested-0.1.4.0-linux-amd64 -O get-tested
-          chmod +x get-tested
-          ./get-tested --ubuntu --macos libsodium-bindings/libsodium-bindings.cabal >> $GITHUB_OUTPUT
+        uses: kleidukos/get-tested@v0.1.6.0
+        with:
+          cabal-file: get-tested.cabal
+          ubuntu: true
+          version: 0.1.6.0
   tests:
     name: ${{ matrix.ghc }} on ${{ matrix.os }}
     needs: generateMatrix
@@ -47,5 +46,3 @@ jobs:
           restore-keys: ${{ runner.os }}-ghc-${{ matrix.ghc }}-
       - name: Build
         run: cabal build libsodium-bindings
-      - name: Test
-        run: cabal test libsodium-bindings

--- a/.github/workflows/libsodium-bindings.yml
+++ b/.github/workflows/libsodium-bindings.yml
@@ -17,7 +17,7 @@ jobs:
         id: set-matrix
         uses: kleidukos/get-tested@v0.1.6.0
         with:
-          cabal-file: get-tested.cabal
+          cabal-file: libsodium-bindings/libsodium-bindings.cabal
           ubuntu: true
           version: 0.1.6.0
   tests:

--- a/.github/workflows/sel.yml
+++ b/.github/workflows/sel.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Configure
         run: |
           ./.github/workflows/install-libsodium.sh
-          cabal freeze
       - name: Cache
         uses: actions/cache@v3.3.2
         with:

--- a/.github/workflows/sel.yml
+++ b/.github/workflows/sel.yml
@@ -13,14 +13,14 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - name: Checkout base repo
-        uses: actions/checkout@v4
       - name: Extract the tested GHC versions
         id: set-matrix
-        run: |
-          wget https://github.com/Kleidukos/get-tested/releases/download/v0.1.4.0/get-tested-0.1.4.0-linux-amd64 -O get-tested
-          chmod +x get-tested
-          ./get-tested --ubuntu --macos sel/sel.cabal >> $GITHUB_OUTPUT
+        uses: kleidukos/get-tested@v0.1.6.0
+        with:
+          cabal-file: sel/sel.cabal
+          ubuntu: true
+          macos: true
+          version: 0.1.6.0
   tests:
     name: ${{ matrix.ghc }} on ${{ matrix.os }}
     needs: generateMatrix

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Haskell Cryptography Group presents its suite of libsodium packages:
 | Name                 | Nature                                     | Dependencies                                                                 | GHC Support          
 |----------------------|--------------------------------------------|------------------------------------------------------------------------------|--------------------  
 | `libsodium‑bindings` | Low-level FFI bindings                     | `base`                                                                       | Starts with 8.10.7   
-| `sel`                | High-level Haskell interface               | `base`, `base16`,  `bytestring`, `text` `text-display`, `libsodium‑bindings` | Starts with 8.10.7 
+| `sel`                | High-level Haskell interface               | `base`, `base16`,  `bytestring`, `text` `text-display`, `libsodium‑bindings` | Starts with 9.2.8
 | `saltine`            | Both FFI bindings and high-level interface | `base`, `bytestring` `deepseq`, `text`, `hashable`, `profunctors`            | Starts with 8.0.2  
 | `libsodium`          | Low-level FFI bindings                     | `base`                                                                       | 8.6.5 to 8.10.1    
 | `crypto‑sodium`      | High-level Haskell interface               | `base`, `bytestring`, `random`, `cereal`, `libsodium`, `memory`,             | Unclear            

--- a/sel/sel.cabal
+++ b/sel/sel.cabal
@@ -15,7 +15,7 @@ maintainer:         The Haskell Cryptography contributors
 license:            BSD-3-Clause
 build-type:         Simple
 tested-with:
-  GHC ==9.2.8 || ==9.4.7 || ==9.6.2
+  GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.7 || ==9.6.2
 
 extra-source-files:
   LICENSE
@@ -63,7 +63,7 @@ library
 
   other-modules:   Sel.Internal
   build-depends:
-    , base                >=4.16.4.0     && <5
+    , base                >=4.14     && <5
     , base16              ^>=1.0
     , bytestring          ^>=0.11
     , libsodium-bindings  ^>=0.0.1.0

--- a/sel/sel.cabal
+++ b/sel/sel.cabal
@@ -15,7 +15,7 @@ maintainer:         The Haskell Cryptography contributors
 license:            BSD-3-Clause
 build-type:         Simple
 tested-with:
-  GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.7 || ==9.6.2
+  GHC ==9.2.8 || ==9.4.7 || ==9.6.2
 
 extra-source-files:
   LICENSE
@@ -63,7 +63,7 @@ library
 
   other-modules:   Sel.Internal
   build-depends:
-    , base                >=4.14     && <5
+    , base                >=4.16.4.0     && <5
     , base16              ^>=1.0
     , bytestring          ^>=0.11
     , libsodium-bindings  ^>=0.0.1.0

--- a/sel/sel.cabal
+++ b/sel/sel.cabal
@@ -100,3 +100,4 @@ test-suite sel-tests
     , tasty               ^>=1.4
     , tasty-hunit         ^>=0.10
     , text
+    , text-display

--- a/sel/src/Sel/Hashing/Password.hs
+++ b/sel/src/Sel/Hashing/Password.hs
@@ -54,8 +54,8 @@ where
 import Control.Monad (void)
 import Data.ByteString (StrictByteString)
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as Char8
 import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Char8 as Char8
 import qualified Data.ByteString.Internal as BS
 import qualified Data.ByteString.Unsafe as BS
 import Data.Text (Text)

--- a/sel/src/Sel/Hashing/Password.hs
+++ b/sel/src/Sel/Hashing/Password.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -57,7 +58,6 @@ import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Internal as BS
 import qualified Data.ByteString.Unsafe as BS
 import Data.Text (Text)
-import qualified Data.Text as Text
 import Data.Text.Display
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy.Builder as Builder
@@ -68,6 +68,7 @@ import System.IO.Unsafe (unsafeDupablePerformIO)
 import Sel.Internal
 
 import qualified Data.Base16.Types as Base16
+import GHC.Generics
 import LibSodium.Bindings.PasswordHashing
 import LibSodium.Bindings.Random
 
@@ -82,6 +83,7 @@ import LibSodium.Bindings.Random
 --
 -- @since 0.0.1.0
 newtype PasswordHash = PasswordHash (ForeignPtr CChar)
+  deriving stock (Generic)
 
 -- | @since 0.0.1.0
 instance Display PasswordHash where
@@ -101,7 +103,10 @@ instance Ord PasswordHash where
 
 -- | @since 0.0.1.0
 instance Show PasswordHash where
-  show = Text.unpack . passwordHashToText
+  show s = showHash s
+    where
+      showHash :: PasswordHash -> String
+      showHash = show . passwordHashToText
 
 -- | Hash the password with the Argon2id algorithm and a set of pre-defined parameters.
 --
@@ -187,14 +192,19 @@ verifyByteString (PasswordHash fPtr) clearTextPassword = unsafeDupablePerformIO 
 --
 -- @since 0.0.1.0
 passwordHashToByteString :: PasswordHash -> StrictByteString
-passwordHashToByteString (PasswordHash fPtr) =
-  BS.fromForeignPtr0 (Foreign.castForeignPtr fPtr) (fromIntegral @CSize @Int cryptoPWHashStrBytes)
+passwordHashToByteString (PasswordHash fPtr) = unsafeDupablePerformIO $
+  Foreign.withForeignPtr fPtr $ \hashPtr ->
+    BS.unsafePackCStringLen (hashPtr, fromIntegral @CSize @Int cryptoPWHashStrBytes)
 
 -- | Convert a 'PasswordHash' to a strict hexadecimal-encoded 'Text'.
 --
 -- @since 0.0.1.0
 passwordHashToText :: PasswordHash -> Text
-passwordHashToText = Text.decodeASCII . passwordHashToByteString
+passwordHashToText passwordHash =
+  let bs = passwordHashToByteString passwordHash
+   in Text.decodeASCII bs
+
+--
 
 -- | Convert a 'PasswordHash' to a hexadecimal-encoded 'StrictByteString'.
 --
@@ -226,9 +236,12 @@ asciiTextToPasswordHash = asciiByteStringToPasswordHash . Text.encodeUtf8
 --
 -- @since 0.0.1.0
 asciiByteStringToPasswordHash :: StrictByteString -> PasswordHash
-asciiByteStringToPasswordHash textualHash =
-  let (fPtr, _length) = BS.toForeignPtr0 textualHash
-   in PasswordHash (castForeignPtr @Word8 @CChar fPtr)
+asciiByteStringToPasswordHash textualHash = unsafeDupablePerformIO $ do
+  destinationFPtr <- Foreign.mallocForeignPtrBytes (fromIntegral cryptoPWHashStrBytes)
+  Foreign.withForeignPtr destinationFPtr $ \destinationPtr -> do
+    BS.useAsCStringLen textualHash $ \(sourcePtr, len) -> do
+      copyBytes destinationPtr sourcePtr len
+      pure $ PasswordHash destinationFPtr
 
 -- | The 'Salt' is used in conjunction with 'hashByteStringWithParams'
 -- when you want to manually provide the piece of data that will
@@ -267,19 +280,19 @@ genSalt =
       (fromIntegral cryptoPWHashSaltBytes)
       (`randombytesBuf` cryptoPWHashSaltBytes)
 
--- | Convert 'Salt to underlying 'StrictByteString' binary.
+-- | Convert 'Salt' to underlying 'StrictByteString' binary.
 --
 -- @since 0.0.2.0
 saltToBinary :: Salt -> StrictByteString
 saltToBinary (Salt bs) = bs
 
--- | Convert 'Salt to a strict hexadecimal-encoded 'Text'.
+-- | Convert 'Salt' to a strict hexadecimal-encoded 'Text'.
 --
 -- @since 0.0.2.0
 saltToHexText :: Salt -> Text
 saltToHexText = Base16.extractBase16 . Base16.encodeBase16 . saltToBinary
 
--- | Convert 'Salt to a hexadecimal-encoded 'StrictByteString'.
+-- | Convert 'Salt' to a hexadecimal-encoded 'StrictByteString'.
 --
 -- @since 0.0.2.0
 saltToHexByteString :: Salt -> StrictByteString

--- a/sel/test/Test/Hashing/Password.hs
+++ b/sel/test/Test/Hashing/Password.hs
@@ -23,8 +23,12 @@ testRoundtripHash :: Assertion
 testRoundtripHash = do
   let password = "hunter2" :: Text
   passwordHash <- Sel.hashText password
-  let textualHash = Sel.passwordHashToByteString passwordHash
-  let passwordHash' = Sel.asciiByteStringToPasswordHash textualHash
+  let passwordHash' = Sel.asciiByteStringToPasswordHash $ Sel.passwordHashToByteString passwordHash
+
+  assertEqual
+    "Original hash and hash from bytestring are the same"
+    passwordHash
+    passwordHash'
 
   assertBool
     "Password hashing is consistent"

--- a/sel/test/Test/Hashing/Password.hs
+++ b/sel/test/Test/Hashing/Password.hs
@@ -2,7 +2,6 @@
 
 module Test.Hashing.Password where
 
-import qualified Data.ByteString.Char8 as BS
 import Data.Function (on)
 import Data.Maybe (isNothing)
 import Data.Text (Text)
@@ -71,7 +70,7 @@ testASCIIRepresentation = do
     "Textual representation is stable using passwordHashToText"
     ("$argon2id$v=19$m=262144,t=3,p=1$" `Text.isPrefixOf` textHash)
 
-  let bsHash = BS.dropWhileEnd (== '\NUL') $ Sel.passwordHashToByteString hash
+  let bsHash = Sel.passwordHashToByteString hash
   let hash2 = Sel.asciiByteStringToPasswordHash bsHash
   assertEqual
     "Can import hash"


### PR DESCRIPTION
I have made the executive decision to strip `'\NUL'` characters from password hash exports.