### PR TITLE
Scaffolding and implementation for new `PublicKey.Signature` API

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,9 +5,12 @@ packages:
 package libsodium-bindings
   ghc-options: -Werror
 
+package sel
+  ghc-options: -Werror
+
 package *
   ghc-options: -haddock
-  documentation: True
 
 test-show-details: direct
 tests: True
+documentation: True

--- a/libsodium-bindings/src/LibSodium/Bindings/CryptoSign.hs
+++ b/libsodium-bindings/src/LibSodium/Bindings/CryptoSign.hs
@@ -321,7 +321,7 @@ foreign import capi "sodium.h crypto_sign_final_verify"
     -- ^ Returns 0 on success, -1 on error.
 
 -- | This function extracts the seed from the
--- secret key secret key and copies it into the buffer holding the seed.
+-- secret key and copies it into the buffer holding the seed.
 -- The size of the seed will be equal to 'cryptoSignSeedBytes'.
 --
 -- /See:/ [crypto_sign_ed25519_sk_to_seed()](https://doc.libsodium.org/public-key_cryptography/public-key_signatures#extracting-the-seed-and-the-public-key-from-the-secret-key)
@@ -336,7 +336,7 @@ foreign import capi "sodium.h crypto_sign_ed25519_sk_to_seed"
     -> IO CInt
     -- ^ Returns 0 on success, -1 on error.
 
--- | This function extracts the public key from the secret key secret key
+-- | This function extracts the public key from the secret key
 -- and copies it into public key.
 -- The size of public key will be equal to 'cryptoSignPublicKeyBytes'.
 --

--- a/sel/CHANGELOG.md
+++ b/sel/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
+## sel-0.0.3.0
+
+* Add utility functions and instances to Sel.PublicKey.Signature ([#153](https://github.com/haskell-cryptography/libsodium-bindings/pull/153))
+
+
 ## sel-0.0.2.0
 
 * Add usages of `secureMain` in examples
 * Depends on libsodium-bindings-0.0.2.0
+

--- a/sel/CHANGELOG.md
+++ b/sel/CHANGELOG.md
@@ -2,8 +2,63 @@
 
 ## sel-0.0.3.0
 
-* Add utility functions and instances to Sel.PublicKey.Signature ([#153](https://github.com/haskell-cryptography/libsodium-bindings/pull/153))
+### New `Sel.PublicKey.Signature` API [#166][166]
+#### Additions
+* Adds `decodePublicKeyHexByteString` and `encodePublicKeyHexByteString` for de/serialization of `PublicKey`s
+* Adds `UnsafeSecretKey` newtype to signal risky operations
+* Adds `decodeSecretKeyHexByteString` and `encodeSecretKeyHexByteString` for de/serialization of `SecretKey`s (with encoding via `UnsafeSecretKey`)
+* Adds `unsafeSecretKeyHexByteString` for direct encoding of `SecretKey`s (prefer explicit use of `UnsafeSecretKey`)
+* Adds `publicKey` for extracting the `PublicKey` from a `SecretKey`
+* Adds `PublicKeyExtractionException`, thrown by `publicKey` on failure
+* Adds `KeyPair PublicKey SecretKey` and `keyPair :: IO KeyPair` along with accessors `public` and `secret`; `OverloadedRecordDot` is also supported
+* Adds `signWith`, a flipped version of `signMessage`
+* Adds `SignatureVerification` for chaining transformations on verified messages
+* Adds `verifiedMessage` for extracting a message with verification data
+* Adds `signature` and `unverifiedMessage` for extracting signature and message parts, respectively, without signature verification
+* Adds `signedMessage` for constructing a `SignedMessage` from a message and a detached signature
+#### Removals
+* `Ord SecretKey` is vulnerable to timing attacks and has been removed; this instance is available on `UnsafeSecretKey`
+#### Deprecations
+``` diff
+- generateKeyPair :: IO (PublicKey, SecretKey)
++ keyPair :: IO KeyPair
+```
 
+``` diff
+- openMessage :: SignedMessage -> PublicKey -> Maybe StrictByteString
++ verifiedMessage :: SignedMessage -> PublicKey -> SignatureVerification StrictByteString
+```
+
+``` diff
+- getSignature :: SignedMessage -> StrictByteString
++ signature :: SignedMessage -> StrictByteString
+```
+
+``` diff
+- unsafeGetMessage :: SignedMessage -> StrictByteString
++ unverifiedMessage :: SignedMessage -> StrictByteString
+```
+
+``` diff
+- mkSignature :: StrictByteString -> StrictByteString -> SignedMessage
++ signedMessage :: StrictByteString -> StrictByteString -> SignedMessage
+```
+
+#### Fixes
+* `Eq SecretKey` uses constant-time comparison to resist timing attacks
+
+### Hexadecimal codec utilities [#166][166]
+#### Additions
+* Adds `encodeHexByteString'`, a configurable encoder for key material, and `encodeHexByteString` using a default copying encoder
+* Adds `decodeHexByteString'`, a configurable decoder for key material, and `decodeHexByteString` using a default copying decoder
+* Adds `showHexEncoding`, for defining `Show` instances in terms of `encodeHexByteString`
+* Adds `KeyMaterialDecodeError` and validation functions for pre-processing `StrictByteString` inputs
+* Adds `KeyPointerSize` for defining a pointer size for key material
+* Adds `keyPointerLength`, the `Int` length of a key material pointer
+* Adds `keyPointer` for allocating a `ForeignPtr CUChar` to contain key material
+* Adds `KeyPointer`, a `deriving via` utility wrapper for deriving `Eq` and `Ord` instances with configurable comparison strategies (short-circuiting or constant-time) for types with a defined `KeyPointerSize`
+
+[166]: https://github.com/haskell-cryptography/libsodium-bindings/pull/166
 
 ## sel-0.0.2.0
 

--- a/sel/sel.cabal
+++ b/sel/sel.cabal
@@ -57,6 +57,7 @@ library
     Sel.HMAC.SHA256
     Sel.HMAC.SHA512
     Sel.HMAC.SHA512_256
+    Sel.Key
     Sel.PublicKey.Cipher
     Sel.PublicKey.Seal
     Sel.PublicKey.Signature
@@ -65,12 +66,13 @@ library
     Sel.SecretKey.Cipher
     Sel.SecretKey.Stream
 
-  other-modules:   Sel.Internal
   other-modules:
     Sel.Internal
     Sel.Internal.Instances
     Sel.Internal.Scoped
     Sel.Internal.Scoped.Foreign
+    Sel.PublicKey.Internal.Signature
+
   build-depends:
     , base                >=4.14     && <5
     , base16              ^>=1.0

--- a/sel/sel.cabal
+++ b/sel/sel.cabal
@@ -63,6 +63,11 @@ library
     Sel.SecretKey.Stream
 
   other-modules:   Sel.Internal
+  other-modules:
+    Sel.Internal
+    Sel.Internal.Instances
+    Sel.Internal.Scoped
+    Sel.Internal.Scoped.Foreign
   build-depends:
     , base                >=4.14     && <5
     , base16              ^>=1.0
@@ -70,6 +75,7 @@ library
     , libsodium-bindings  ^>=0.0.2
     , text                >=1.2      && <2.2
     , text-display        ^>=0.0
+    , transformers        ^>=0.6.0
 
 test-suite sel-tests
   import:         common

--- a/sel/sel.cabal
+++ b/sel/sel.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               sel
-version:            0.0.2.0
+version:            0.0.3.0
 category:           Cryptography
 synopsis:           Cryptography for the casual user
 description:

--- a/sel/sel.cabal
+++ b/sel/sel.cabal
@@ -45,6 +45,9 @@ library
   hs-source-dirs:  src
   exposed-modules:
     Sel
+    Sel.ByteString.Codec
+    Sel.ByteString.Codec.KeyMaterialDecodeError
+    Sel.ByteString.Codec.KeyPointer
     Sel.Hashing
     Sel.Hashing.Password
     Sel.Hashing.SHA256

--- a/sel/src/Sel/ByteString/Codec.hs
+++ b/sel/src/Sel/ByteString/Codec.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      : Sel.ByteString.Codec
+-- Description : Base16 codecs for cryptographic key material
+-- Copyright   : (c) Jack Henahan, 2024
+-- License     : BSD-3-Clause
+-- Maintainer  : The Haskell Cryptography Group
+-- Portability : GHC only
+--
+-- This module provides utility functions for working with
+-- hexadecimal-encoded ('Base16') cryptographic key material.
+module Sel.ByteString.Codec
+  ( -- * Base 16 codecs for key material
+
+    -- ** Encoding key material to hexadecimal bytes
+    encodeHexByteString'
+  , encodeHexByteString
+
+    -- ** Decoding hexadecimal bytes to key material
+  , decodeHexByteString'
+  , decodeHexByteString
+
+    -- ** Defining instances
+  , showHexEncoding
+  )
+where
+
+import Control.Monad ((>=>))
+import Data.Base16.Types (Base16)
+import Data.Base16.Types qualified as Base16
+import Data.ByteString (StrictByteString)
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Internal qualified as ByteString
+import Data.Coerce (coerce)
+import Data.Word (Word8)
+import Foreign qualified
+import Foreign.C (CUChar)
+import Sel.ByteString.Codec.KeyMaterialDecodeError
+  ( KeyMaterialDecodeError (..)
+  , validKeyMaterialHexBytes
+  )
+import Sel.ByteString.Codec.KeyPointer
+  ( KeyCoerce
+  , keyPointerLength
+  )
+import Sel.Key
+
+-- | Encode key material with a known pointer size by copying and
+-- encoding the bytes.
+--
+-- @since 0.0.3.0
+copyingEncoder :: forall a. KeyCoerce a => a -> Base16 StrictByteString
+copyingEncoder k =
+  Base16.encodeBase16' $
+    ByteString.fromForeignPtr0
+      (Foreign.castForeignPtr @CUChar @Word8 (coerce k))
+      (keyPointerLength @a)
+
+-- | Convert key material to a hexadecimal-encoded 'StrictByteString'
+-- using a provided hexadecimal encoder.
+--
+-- @since 0.0.3.0
+encodeHexByteString' :: (k -> Base16 StrictByteString) -> k -> StrictByteString
+encodeHexByteString' encoder = Base16.extractBase16 . encoder
+
+-- | Convert key material to a hexadecimal-encoded 'StrictByteString'
+-- using the default copying encoder.
+--
+-- @since 0.0.3.0
+encodeHexByteString :: KeyCoerce k => k -> StrictByteString
+encodeHexByteString = encodeHexByteString' copyingEncoder
+
+-- | Derive 'Show' via the hexadecimal representation of some key
+-- material, using the default copying encoder.
+--
+-- @since 0.0.3.0
+showHexEncoding :: KeyCoerce k => k -> String
+showHexEncoding = ByteString.unpackChars . encodeHexByteString
+
+-- | Decode key material with a known pointer size by copying the
+-- bytes into a fresh key.
+--
+-- @since 0.0.3.0
+copyingDecoder :: KeyCoerce k => Base16 StrictByteString -> Either KeyMaterialDecodeError k
+copyingDecoder = toKey . Base16.decodeBase16
+
+-- | Decode a hexadecimal-encoded 'StrictByteString' to key material
+-- using a provided hexadecimal decoder, yielding a
+-- 'KeyMaterialDecodeError' on failure.
+--
+-- @since 0.0.3.0
+decodeHexByteString'
+  :: (Base16 StrictByteString -> Either KeyMaterialDecodeError k)
+  -> StrictByteString
+  -> Either KeyMaterialDecodeError k
+decodeHexByteString' decoder = validKeyMaterialHexBytes >=> decoder
+
+-- | Decode a hexadecimal-encoded 'StrictByteString' to key material
+-- using the default copying decoder, yielding a
+-- 'KeyMaterialDecodeError' on failure.
+--
+-- @since 0.0.3.0
+decodeHexByteString :: KeyCoerce k => StrictByteString -> Either KeyMaterialDecodeError k
+decodeHexByteString = decodeHexByteString' copyingDecoder

--- a/sel/src/Sel/ByteString/Codec/KeyMaterialDecodeError.hs
+++ b/sel/src/Sel/ByteString/Codec/KeyMaterialDecodeError.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- |
+-- Module      : Sel.ByteString.Codec.KeyMaterialDecodeError
+-- Description : Decoding errors for cryptographic key material
+-- Copyright   : (c) Jack Henahan, 2024
+-- License     : BSD-3-Clause
+-- Maintainer  : The Haskell Cryptography Group
+-- Portability : GHC only
+--
+-- This module models common error cases when decoding cryptographic
+-- key material and provides utilities for validating key material
+-- during decoding.
+module Sel.ByteString.Codec.KeyMaterialDecodeError
+  ( KeyMaterialDecodeError (..)
+  , RequiredLength (..)
+  , InputLength (..)
+  , validKeyMaterialHexBytes
+  , validKeyMaterialLength
+  ) where
+
+import Control.Exception (Exception)
+import Data.Base16.Types (Base16)
+import Data.Bifunctor (bimap)
+import Data.ByteString (StrictByteString)
+import Data.ByteString qualified as ByteString
+import Data.ByteString.Base16 qualified as Base16
+import Data.Coerce (coerce)
+import Data.Text (Text)
+import Data.Text.Display (Display, ShowInstance (..))
+import Sel.ByteString.Codec.KeyPointer (KeyPointerSize, keyPointerLength)
+
+-- | Errors arising from decoding key material from bytes.
+--
+-- @since 0.0.3.0
+data KeyMaterialDecodeError
+  = -- | Input length does not match the length required for the target pointer.
+    --
+    -- @since 0.0.3.0
+    ByteLengthMismatch RequiredLength InputLength
+  | -- | Input bytes did not decode to hexadecimal.
+    --
+    -- @since 0.0.3.0
+    DecodingFailure Text
+  deriving stock
+    ( Show
+      -- ^ @since 0.0.3.0
+    , Eq
+      -- ^ @since 0.0.3.0
+    )
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+    )
+    via (ShowInstance KeyMaterialDecodeError)
+  deriving anyclass
+    ( Exception
+      -- ^ @since 0.0.3.0
+    )
+
+-- | The length of the target pointer for some key material.
+--
+-- @since 0.0.3.0
+newtype RequiredLength = RequiredLength Int
+  deriving stock
+    ( Show
+      -- ^ @since 0.0.3.0
+    , Eq
+      -- ^ @since 0.0.3.0
+    )
+
+-- | The length of some input bytes.
+--
+-- @since 0.0.3.0
+newtype InputLength = InputLength Int
+  deriving stock
+    ( Show
+      -- ^ @since 0.0.3.0
+    , Eq
+      -- ^ @since 0.0.3.0
+    )
+
+-- | Decode a hexadecimal-encoded 'StrictByteString' to a 'Base16'
+-- 'StrictByteString'.
+--
+-- @since 0.0.3.0
+validKeyMaterialHexBytes :: StrictByteString -> Either KeyMaterialDecodeError (Base16 StrictByteString)
+validKeyMaterialHexBytes = bimap DecodingFailure Base16.encodeBase16' . Base16.decodeBase16Untyped
+
+-- | Ensure the provided bytes match the expected length of the target
+-- pointer.
+--
+-- @since 0.0.3.0
+validKeyMaterialLength
+  :: forall a
+   . KeyPointerSize a
+  => StrictByteString
+  -> Either KeyMaterialDecodeError StrictByteString
+validKeyMaterialLength bs@(ByteString.length -> inputLength) =
+  guardEither
+    (requiredLength == inputLength)
+    (ByteLengthMismatch (coerce requiredLength) (coerce inputLength))
+    bs
+  where
+    requiredLength = keyPointerLength @a
+
+guardEither :: Bool -> a -> b -> Either a b
+guardEither p f t = if p then Right t else Left f

--- a/sel/src/Sel/ByteString/Codec/KeyPointer.hs
+++ b/sel/src/Sel/ByteString/Codec/KeyPointer.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Module      : Sel.ByteString.Codec.KeyPointer
+-- Description : Pointer utilities for cryptographic key material
+-- Copyright   : (c) Jack Henahan, 2024
+-- License     : BSD-3-Clause
+-- Maintainer  : The Haskell Cryptography Group
+-- Portability : GHC only
+--
+-- This module provides a type class for describing pointer sizes for
+-- cryptographic key material along with utilities for creating such
+-- pointers and deriving common instances based on the pointer size.
+module Sel.ByteString.Codec.KeyPointer
+  ( -- * Key material pointer utilities
+    KeyPointerSize (..)
+  , keyPointer
+  , keyPointerLength
+
+    -- ** Deriving instances
+  , KeyPointer (..)
+  , type KeyCoerce
+  , type ComparisonImplementation (..)
+  )
+where
+
+import Data.Coerce (Coercible, coerce)
+import Data.Kind (Type)
+import Foreign (ForeignPtr, mallocForeignPtrBytes)
+import Foreign.C (CSize, CUChar)
+import Sel.Internal.Instances
+import System.IO.Unsafe (unsafeDupablePerformIO)
+
+-- | Define the size of the pointer for some key material.
+--
+-- @since 0.0.3.0
+class KeyPointerSize a where
+  keyPointerSize :: CSize
+  -- ^ @since 0.0.3.0
+
+-- | Length of the pointer for some key material.
+--
+-- @since 0.0.3.0
+keyPointerLength :: forall a. KeyPointerSize a => Int
+keyPointerLength = fromIntegral @CSize @Int (keyPointerSize @a)
+
+-- | Allocate a 'ForeignPtr' 'CUChar' for some key material.
+--
+-- @since 0.0.3.0
+keyPointer :: forall a. KeyPointerSize a => IO (ForeignPtr CUChar)
+keyPointer = mallocForeignPtrBytes $ keyPointerLength @a
+
+-- | Tag denoting the characteristics of the desired pointer comparison.
+--
+-- Secret material should always use 'Constant', but public material
+-- may use short-circuiting comparison for performance unless
+-- otherwise specified by the @libsodium@ docs.
+--
+-- @since 0.0.3.0
+data ComparisonImplementation
+  = -- | Use byte-wise (short-circuiting) comparison.
+    --
+    -- @since 0.0.3.0
+    ShortCircuiting
+  | -- | Use constant-time comparison.
+    --
+    -- @since 0.0.3.0
+    ConstantTime
+
+-- | A wrapper to enable deriving instances from the size of a key
+-- material pointer.
+--
+-- === Example
+--
+-- @
+-- newtype SomeKeyMaterial = SomeKeyMaterial (ForeignPtr CUChar)
+--   deriving (Eq, Ord) via (KeyPointer SomeKeyMaterial ShortCircuiting)
+--
+-- instance KeyPointerSize SomeKeyMaterial where
+--   keyPointerSize :: CSize
+--   keyPointerSize = {- get your size from the FFI bindings -}
+-- @
+--
+-- @since 0.0.3.0
+newtype KeyPointer (a :: Type) (cmp :: ComparisonImplementation) = KeyPointer a
+
+-- | Demand a known pointer size and an underlying pointer coercible
+-- to a @'ForeignPtr' 'CUChar'@.
+--
+-- @since 0.0.3.0
+type KeyCoerce a = (KeyPointerSize a, Coercible a (ForeignPtr CUChar))
+
+-- | Byte-wise (short-circuiting) pointer equality.
+--
+-- ⚠️ This instance is vulnerable to timing attacks. Prefer the
+-- 'ConstantTime' instance for secret material.
+--
+-- @since 0.0.3.0
+instance KeyCoerce a => Eq (KeyPointer a ShortCircuiting) where
+  a == b =
+    unsafeDupablePerformIO $
+      foreignPtrEq (coerce a) (coerce b) (keyPointerSize @a)
+
+-- | Constant-time pointer equality.
+--
+-- @since 0.0.3.0
+instance KeyCoerce a => Eq (KeyPointer a ConstantTime) where
+  a == b =
+    unsafeDupablePerformIO $
+      foreignPtrEqConstantTime (coerce a) (coerce b) (keyPointerSize @a)
+
+-- | Byte-wise (short-circuiting) pointer comparison.
+--
+-- ⚠️ This instance is vulnerable to timing attacks.
+--
+-- @since 0.0.3.0
+instance (KeyCoerce a, Eq (KeyPointer a cmp)) => Ord (KeyPointer a cmp) where
+  compare a b =
+    unsafeDupablePerformIO $
+      foreignPtrOrd (coerce a) (coerce b) (keyPointerSize @a)

--- a/sel/src/Sel/HMAC/SHA256.hs
+++ b/sel/src/Sel/HMAC/SHA256.hs
@@ -81,7 +81,8 @@ import LibSodium.Bindings.SHA2
   , cryptoAuthHMACSHA256Verify
   )
 import LibSodium.Bindings.SecureMemory (finalizerSodiumFree, sodiumMalloc)
-import Sel.Internal (allocateWith, foreignPtrEq, foreignPtrOrd)
+import Sel.Internal
+import Sel.Internal.Instances
 
 -- $introduction
 -- The 'authenticate' function computes an authentication tag for a message and a secret key,

--- a/sel/src/Sel/HMAC/SHA512.hs
+++ b/sel/src/Sel/HMAC/SHA512.hs
@@ -81,7 +81,8 @@ import LibSodium.Bindings.SHA2
   , cryptoAuthHMACSHA512Verify
   )
 import LibSodium.Bindings.SecureMemory (finalizerSodiumFree, sodiumMalloc)
-import Sel.Internal (allocateWith, foreignPtrEq, foreignPtrOrd)
+import Sel.Internal
+import Sel.Internal.Instances
 
 -- $introduction
 -- The 'authenticate' function computes an authentication tag for a message and a secret key,

--- a/sel/src/Sel/HMAC/SHA512_256.hs
+++ b/sel/src/Sel/HMAC/SHA512_256.hs
@@ -79,7 +79,8 @@ import LibSodium.Bindings.SHA2
   , cryptoAuthHMACSHA512256Verify
   )
 import LibSodium.Bindings.SecureMemory (finalizerSodiumFree, sodiumMalloc)
-import Sel.Internal (allocateWith, foreignPtrEq, foreignPtrOrd)
+import Sel.Internal
+import Sel.Internal.Instances
 
 -- $introduction
 -- The 'authenticate' function computes an authentication tag for a message and a secret key,

--- a/sel/src/Sel/Hashing.hs
+++ b/sel/src/Sel/Hashing.hs
@@ -66,6 +66,7 @@ import LibSodium.Bindings.GenericHashing
   , cryptoGenericHashUpdate
   )
 import Sel.Internal
+import Sel.Internal.Instances
 
 -- $introduction
 --

--- a/sel/src/Sel/Hashing/Password.hs
+++ b/sel/src/Sel/Hashing/Password.hs
@@ -67,7 +67,7 @@ import Foreign hiding (void)
 import Foreign.C
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
-import Sel.Internal
+import Sel.Internal.Instances
 
 import qualified Data.Base16.Types as Base16
 import GHC.Generics
@@ -95,13 +95,13 @@ instance Display PasswordHash where
 instance Eq PasswordHash where
   (PasswordHash ph1) == (PasswordHash ph2) =
     unsafeDupablePerformIO $
-      foreignPtrEq ph1 ph2 cryptoPWHashStrBytes
+      foreignPtrEq (Foreign.castForeignPtr ph1) (Foreign.castForeignPtr ph2) cryptoPWHashStrBytes
 
 -- | @since 0.0.1.0
 instance Ord PasswordHash where
   (PasswordHash ph1) `compare` (PasswordHash ph2) =
     unsafeDupablePerformIO $
-      foreignPtrOrd ph1 ph2 cryptoPWHashStrBytes
+      foreignPtrOrd (Foreign.castForeignPtr ph1) (Foreign.castForeignPtr ph2) cryptoPWHashStrBytes
 
 -- | @since 0.0.1.0
 instance Show PasswordHash where

--- a/sel/src/Sel/Hashing/SHA256.hs
+++ b/sel/src/Sel/Hashing/SHA256.hs
@@ -59,6 +59,7 @@ import Control.Monad.IO.Class (MonadIO (liftIO))
 import qualified Data.Base16.Types as Base16
 import Data.Kind (Type)
 import Sel.Internal
+import Sel.Internal.Instances
 
 -- $usage
 --

--- a/sel/src/Sel/Hashing/SHA512.hs
+++ b/sel/src/Sel/Hashing/SHA512.hs
@@ -59,6 +59,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Data.Base16.Types as Base16
 import Data.Kind (Type)
 import Sel.Internal
+import Sel.Internal.Instances
 
 -- $usage
 --

--- a/sel/src/Sel/Hashing/Short.hs
+++ b/sel/src/Sel/Hashing/Short.hs
@@ -55,7 +55,6 @@ import qualified Data.Text.Lazy.Builder as Builder
 import Foreign hiding (void)
 import Foreign.C (CSize, CUChar, CULLong)
 import GHC.Exception (Exception)
-import GHC.IO.Handle.Text (memcpy)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
 import qualified Data.Base16.Types as Base16
@@ -66,7 +65,7 @@ import LibSodium.Bindings.ShortHashing
   , cryptoShortHashX24
   , cryptoShortHashX24KeyGen
   )
-import Sel.Internal
+import Sel.Internal.Instances
 
 -- $introduction
 --
@@ -254,7 +253,7 @@ binaryToShortHashKey binaryKey =
       BS.unsafeUseAsCString binaryKey $ \cString -> do
         shortHashKeyFPtr <- Foreign.mallocForeignPtrBytes (fromIntegral cryptoShortHashSipHashX24KeyBytes)
         Foreign.withForeignPtr shortHashKeyFPtr $ \shortHashKeyPtr ->
-          memcpy shortHashKeyPtr (Foreign.castPtr cString) cryptoShortHashSipHashX24KeyBytes
+          Foreign.copyBytes shortHashKeyPtr (Foreign.castPtr cString) (fromIntegral cryptoShortHashSipHashX24KeyBytes)
         pure $ Just $ ShortHashKey shortHashKeyFPtr
 
 -- | Convert a strict hexadecimal-encoded 'Text' to a 'ShortHashKey'.

--- a/sel/src/Sel/Internal.hs
+++ b/sel/src/Sel/Internal.hs
@@ -1,53 +1,14 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Sel.Internal where
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import qualified Data.Base16.Types as Base16
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.ByteString.Internal as BS
 import Data.Kind (Type)
-import Foreign (Ptr, castForeignPtr)
-import Foreign.C.Types (CInt (CInt), CSize (CSize))
-import Foreign.ForeignPtr (ForeignPtr, withForeignPtr)
+import Foreign (Ptr)
+import Foreign.C (CSize)
 import LibSodium.Bindings.SecureMemory (sodiumFree, sodiumMalloc)
-
--- | This calls to C's @memcmp@ function, used in lieu of
--- libsodium's @memcmp@ in cases when the return code is necessary.
-foreign import capi unsafe "string.h memcmp"
-  memcmp :: Ptr a -> Ptr b -> CSize -> IO CInt
-
--- | Compare if the contents of two @ForeignPtr@s are equal.
-foreignPtrEq :: ForeignPtr a -> ForeignPtr a -> CSize -> IO Bool
-foreignPtrEq fptr1 fptr2 size =
-  withForeignPtr fptr1 $ \p ->
-    withForeignPtr fptr2 $ \q ->
-      do
-        result <- memcmp p q size
-        return $ 0 == result
-
--- | Compare the contents of two @ForeignPtr@s using lexicographical ordering.
-foreignPtrOrd :: ForeignPtr a -> ForeignPtr a -> CSize -> IO Ordering
-foreignPtrOrd fptr1 fptr2 size =
-  withForeignPtr fptr1 $ \p ->
-    withForeignPtr fptr2 $ \q ->
-      do
-        result <- memcmp p q size
-        return $
-          if
-            | result == 0 -> EQ
-            | result < 0 -> LT
-            | otherwise -> GT
-
-foreignPtrShow :: ForeignPtr a -> CSize -> String
-foreignPtrShow fptr size =
-  BS.unpackChars . Base16.extractBase16 . Base16.encodeBase16' $
-    BS.fromForeignPtr (Foreign.castForeignPtr fptr) 0 (fromIntegral @CSize @Int size)
 
 -- | Securely allocate an amount of memory with 'sodiumMalloc' and pass
 -- a pointer to the region to the provided action.

--- a/sel/src/Sel/Internal/Instances.hs
+++ b/sel/src/Sel/Internal/Instances.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- |
+-- Module      : Sel.Internal.Instances
+-- Description : Type class method implementations for pointer-backed types
+-- Copyright   : (c) Jack Henahan, 2024
+-- License     : BSD-3-Clause
+-- Maintainer  : The Haskell Cryptography Group
+-- Portability : GHC only
+module Sel.Internal.Instances where
+
+import Data.Base16.Types qualified as Base16
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Internal (memcmp)
+import Data.ByteString.Unsafe qualified as ByteString
+import Data.Coerce (coerce)
+import Foreign qualified
+import Foreign.C (CChar, CSize, CUChar)
+import Foreign.ForeignPtr (ForeignPtr)
+import LibSodium.Bindings.Comparison (sodiumMemcmp)
+import Sel.Internal.Scoped
+import Sel.Internal.Scoped.Foreign
+
+-- | Compare the contents of two byte arrays in constant time.
+--
+-- /See:/ [Constant-time test for equality](https://doc.libsodium.org/helpers#constant-time-test-for-equality)
+--
+-- @since 0.0.3.0
+foreignPtrEqConstantTime :: ForeignPtr CUChar -> ForeignPtr CUChar -> CSize -> IO Bool
+foreignPtrEqConstantTime p q size =
+  fmap (== 0) . use $
+    sodiumMemcmp <$> foreignPtr p <*> foreignPtr q <*> pure size
+
+-- | Lexicographically compare the contents of two byte arrays.
+--
+-- ⚠️ Such comparisons are vulnerable to timing attacks, and should be
+-- avoided for secret data.
+--
+-- @since 0.0.1.0
+foreignPtrOrd :: ForeignPtr CUChar -> ForeignPtr CUChar -> CSize -> IO Ordering
+foreignPtrOrd p q size =
+  fmap (`compare` 0) . useM $
+    memcmp
+      <$> foreignPtr (coerce p)
+      <*> foreignPtr (coerce q)
+      <*> pure (fromIntegral size)
+
+-- | Compare two byte arrays for lexicographic equality.
+--
+-- ⚠️ Such comparisons are vulnerable to timing attacks, and should be
+-- avoided for secret data.
+--
+-- @since 0.0.1.0
+foreignPtrEq :: ForeignPtr CUChar -> ForeignPtr CUChar -> CSize -> IO Bool
+foreignPtrEq p q size = (== EQ) <$> foreignPtrOrd p q size
+
+-- | Convert a @'ForeignPtr' a@ to a 'ByteString' of the given length
+-- and render the hexadecimal-encoded bytes as a 'String'.
+--
+-- @since 0.0.1.0
+foreignPtrShow :: ForeignPtr a -> CSize -> IO String
+foreignPtrShow (Foreign.castForeignPtr @_ @CChar -> cstring) size =
+  fmap (show . Base16.extractBase16 . Base16.encodeBase16')
+    . useM
+    $ curry ByteString.unsafePackMallocCStringLen
+      <$> foreignPtr cstring
+      <*> pure (fromIntegral size)

--- a/sel/src/Sel/Internal/Scoped.hs
+++ b/sel/src/Sel/Internal/Scoped.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Module      : Sel.Internal.Scoped
+-- Description : Continuation-passing utilities
+-- Copyright   : (c) Jack Henahan, 2024
+-- License     : BSD-3-Clause
+-- Maintainer  : The Haskell Cryptography Group
+-- Portability : GHC only
+--
+-- This module implements a version of @Codensity@, modeling delimited
+-- continuations. Useful for avoiding extreme rightward drift in
+-- chains of @withForeignPtr@ and friends.
+module Sel.Internal.Scoped where
+
+import Control.Monad (ap, void)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Control.Monad.Trans.Class (MonadTrans (lift))
+import Data.Kind (Type)
+import Data.Type.Equality (type (~~))
+import GHC.Exts (RuntimeRep, TYPE)
+
+-- | @since 0.0.3.0
+type Scoped :: forall {k} {rep :: RuntimeRep}. (k -> TYPE rep) -> Type -> Type
+newtype Scoped m a = Scoped {runScoped :: forall b. (a -> m b) -> m b}
+
+-- | @since 0.0.3.0
+instance Functor (Scoped f) where
+  fmap f (Scoped m) = Scoped $ \k -> m (k . f)
+  {-# INLINE fmap #-}
+
+-- | @since 0.0.3.0
+instance Applicative (Scoped f) where
+  pure a = Scoped $ \k -> k a
+  {-# INLINE pure #-}
+
+  (<*>) = ap
+  {-# INLINE (<*>) #-}
+
+-- | @since 0.0.3.0
+instance Monad (Scoped f) where
+  Scoped m >>= f = Scoped $ \k ->
+    m $ \a -> runScoped (f a) k
+  {-# INLINE (>>=) #-}
+
+-- | @since 0.0.3.0
+instance (MonadIO m', m' ~~ m) => MonadIO (Scoped m) where
+  liftIO = lift . liftIO
+  {-# INLINE liftIO #-}
+
+-- | @since 0.0.3.0
+instance MonadTrans Scoped where
+  lift m = Scoped (m >>=)
+  {-# INLINE lift #-}
+
+-- | @since 0.0.3.0
+reset :: Monad m => Scoped m a -> Scoped m a
+reset = lift . use
+
+-- | @since 0.0.3.0
+shift :: Applicative m => (forall b. (a -> m b) -> Scoped m b) -> Scoped m a
+shift f = Scoped $ use . f
+
+-- | @since 0.0.3.0
+use :: Applicative m => Scoped m a -> m a
+use (Scoped m) = m pure
+
+-- | @since 0.0.3.0
+useM :: Monad m => Scoped m (m a) -> m a
+useM f = use $ f >>= lift
+
+-- | @since 0.0.3.0
+use_ :: Applicative m => Scoped m a -> m ()
+use_ = void . use
+
+-- | @since 0.0.3.0
+useM_ :: Monad m => Scoped m (m a) -> m ()
+useM_ = void . useM

--- a/sel/src/Sel/Internal/Scoped/Foreign.hs
+++ b/sel/src/Sel/Internal/Scoped/Foreign.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+
+-- |
+-- Module      : Sel.Internal.Scoped.Foreign
+-- Description : Scoped wrappers around pointer manipulation
+-- Copyright   : (c) Jack Henahan, 2024
+-- License     : BSD-3-Clause
+-- Maintainer  : The Haskell Cryptography Group
+-- Portability : GHC only
+--
+-- This module wraps some common points of contact with 'Ptr',
+-- 'ForeignPtr', and friends up in 'Scoped' for the sake of not saying
+-- 'lift' absolutely everywhere.
+module Sel.Internal.Scoped.Foreign where
+
+import Control.Monad.Trans.Class (lift)
+import Data.ByteString (StrictByteString)
+import Data.ByteString.Unsafe qualified as ByteString
+import Foreign (ForeignPtr, Ptr, Storable)
+import Foreign qualified
+import Foreign.C (CString, CStringLen)
+import Sel.Internal.Scoped
+
+-- | @since 0.0.3.0
+foreignPtr :: ForeignPtr a -> Scoped IO (Ptr a)
+foreignPtr fptr = Scoped $ Foreign.withForeignPtr fptr
+
+-- | @since 0.0.3.0
+unsafeCStringLen :: StrictByteString -> Scoped IO CStringLen
+unsafeCStringLen bs = Scoped $ ByteString.unsafeUseAsCStringLen bs
+
+-- | @since 0.0.3.0
+unsafeCString :: StrictByteString -> Scoped IO CString
+unsafeCString bs = Scoped $ ByteString.unsafeUseAsCString bs
+
+-- | @since 0.0.3.0
+mallocBytes :: Int -> Scoped IO (Ptr a)
+mallocBytes = lift . Foreign.mallocBytes
+
+-- | @since 0.0.3.0
+mallocForeignPtrBytes :: Int -> Scoped IO (ForeignPtr a)
+mallocForeignPtrBytes len = lift $ Foreign.mallocForeignPtrBytes len
+
+-- | @since 0.0.3.0
+copyArray :: Storable a => Ptr a -> Ptr a -> Int -> Scoped IO ()
+copyArray target source len = lift $ Foreign.copyArray target source len

--- a/sel/src/Sel/Key.hs
+++ b/sel/src/Sel/Key.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      : Sel.Key
+-- Description : Key material utilities
+-- Copyright   : (c) Jack Henahan, 2024
+-- License     : BSD-3-Clause
+-- Maintainer  : The Haskell Cryptography Group
+-- Portability : GHC only
+module Sel.Key
+  ( -- * Key material utilities
+    toKey
+  , newKeyWith
+  )
+where
+
+import Control.Monad (when)
+import Data.ByteString (StrictByteString)
+import Data.ByteString.Unsafe qualified as ByteString
+import Data.Coerce (coerce)
+import Foreign (Ptr, castPtr, copyArray, newForeignPtr, nullPtr)
+import Foreign.C (CChar, CSize, CUChar, throwErrno)
+import LibSodium.Bindings.SecureMemory (finalizerSodiumFree, sodiumMalloc)
+import Sel.ByteString.Codec.KeyMaterialDecodeError
+import Sel.ByteString.Codec.KeyPointer
+import System.IO.Unsafe (unsafeDupablePerformIO)
+
+-- | Copy a byte array as key material.
+--
+-- The size of the array is checked against the size of the target
+-- pointer.
+--
+-- @since 0.0.3.0
+toKey :: forall a. KeyCoerce a => StrictByteString -> Either KeyMaterialDecodeError a
+toKey s = unsafeCopyKey <$> validKeyMaterialLength @a s
+
+-- | Copy a byte array as key material.
+--
+-- The size of the array is not checked. The input may be truncated if
+-- it is too long, or an unchecked exception may be thrown if it is
+-- too short.
+--
+-- @since 0.0.3.0
+unsafeCopyKey :: forall a. KeyCoerce a => StrictByteString -> a
+unsafeCopyKey s = unsafeDupablePerformIO $
+  ByteString.unsafeUseAsCString s $ \str ->
+    newKeyWith @a $ \k ->
+      Foreign.copyArray
+        (Foreign.castPtr @CUChar @CChar k)
+        str
+        (fromIntegral @CSize @Int (keyPointerSize @a))
+
+-- | Allocate memory for key material and populate it with the provided action.
+--
+-- Memory is allocated with 'LibSodium.Bindings.SecureMemory.sodiumMalloc' (see notes).
+--
+-- A finalizer frees the memory when the key goes out of scope.
+--
+-- @since 0.0.3.0
+newKeyWith :: forall a. KeyCoerce a => (Ptr CUChar -> IO ()) -> IO a
+newKeyWith action = do
+  ptr <- sodiumMalloc (keyPointerSize @a)
+  when (ptr == Foreign.nullPtr) $ do
+    throwErrno "sodium_malloc"
+  fptr <- Foreign.newForeignPtr finalizerSodiumFree ptr
+  action ptr
+  pure $ coerce fptr

--- a/sel/src/Sel/PublicKey/Cipher.hs
+++ b/sel/src/Sel/PublicKey/Cipher.hs
@@ -64,7 +64,6 @@ import Foreign (ForeignPtr, Ptr)
 import qualified Foreign
 import Foreign.C (CChar, CSize, CUChar, CULLong)
 import qualified Foreign.C as Foreign
-import GHC.IO.Handle.Text (memcpy)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
 import Control.Exception
@@ -80,7 +79,7 @@ import LibSodium.Bindings.CryptoBox
   )
 import LibSodium.Bindings.Random (randombytesBuf)
 import LibSodium.Bindings.SecureMemory (finalizerSodiumFree, sodiumFree, sodiumMalloc)
-import Sel.Internal
+import Sel.Internal.Instances
 
 -- $introduction
 -- Public-key authenticated encryption allows a sender to encrypt a confidential message
@@ -512,10 +511,10 @@ decrypt
               (-1) -> pure Nothing
               _ -> do
                 bsPtr <- Foreign.mallocBytes (fromIntegral messageLength)
-                memcpy bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLength)
+                Foreign.copyBytes bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLength)
                 Just
                   <$> BS.unsafePackMallocCStringLen
-                    (Foreign.castPtr @CChar bsPtr, fromIntegral messageLength)
+                    (Foreign.castPtr @CUChar @CChar bsPtr, fromIntegral messageLength)
 
 -- | Exception thrown upon error during the generation of
 -- the key pair by 'newKeyPair'.

--- a/sel/src/Sel/PublicKey/Internal/Signature.hs
+++ b/sel/src/Sel/PublicKey/Internal/Signature.hs
@@ -1,0 +1,478 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+module Sel.PublicKey.Internal.Signature
+  ( -- ** Public Keys
+    PublicKey
+  , decodePublicKeyHexByteString
+  , encodePublicKeyHexByteString
+
+    -- ** Secret Keys
+  , SecretKey
+  , decodeSecretKeyHexByteString
+  , encodeSecretKeyHexByteString
+  , UnsafeSecretKey (..)
+  , publicKey
+
+    -- ** Key Pairs
+  , KeyPair (..)
+  , public
+  , secret
+  , keyPair
+
+    -- ** Signed Messages
+  , SignedMessage
+  , sign
+  , open
+  , SignatureVerification (..)
+  , extractUnverifiedMessage
+  , extractSignature
+  , buildSignedMessage
+
+    -- ** Exceptions
+  , PublicKeyExtractionException (..)
+  )
+where
+
+import Control.Exception (Exception, throw)
+import Control.Monad (unless)
+import Control.Monad.Trans.Class (lift)
+import Data.ByteString (StrictByteString)
+import Data.ByteString.Unsafe qualified as ByteString
+import Data.Ord (comparing)
+import Data.Text.Display (Display, OpaqueInstance (..), ShowInstance (..))
+import Foreign (ForeignPtr)
+import Foreign qualified
+import Foreign.C (CChar, CSize, CUChar, CULLong)
+import LibSodium.Bindings.CryptoSign
+  ( cryptoSignBytes
+  , cryptoSignDetached
+  , cryptoSignED25519SkToPk
+  , cryptoSignKeyPair
+  , cryptoSignPublicKeyBytes
+  , cryptoSignSecretKeyBytes
+  , cryptoSignVerifyDetached
+  )
+import Sel.ByteString.Codec
+  ( decodeHexByteString
+  , encodeHexByteString
+  , showHexEncoding
+  )
+import Sel.ByteString.Codec.KeyMaterialDecodeError
+import Sel.ByteString.Codec.KeyPointer
+import Sel.Internal.Instances
+  ( foreignPtrEq
+  , foreignPtrOrd
+  , foreignPtrShow
+  )
+import Sel.Internal.Scoped
+import Sel.Internal.Scoped.Foreign
+  ( copyArray
+  , foreignPtr
+  , mallocBytes
+  , mallocForeignPtrBytes
+  , unsafeCString
+  , unsafeCStringLen
+  )
+import System.IO.Unsafe (unsafeDupablePerformIO)
+
+-- | A public key of size 'cryptoSignPublicKeyBytes', suitable for
+-- publication to third parties for message verification.
+newtype PublicKey = PublicKey (ForeignPtr CUChar)
+  deriving
+    ( Eq
+      -- ^ @since 0.0.1.0
+      -- By lexicographical comparison of pointer contents.
+    , Ord
+      -- ^ @since 0.0.1.0
+      -- By lexicographical comparison of pointer contents.
+    )
+    via (KeyPointer PublicKey ShortCircuiting)
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+      -- Hexadecimal-encoded bytes.
+    )
+    via (ShowInstance PublicKey)
+
+-- | Decode a hexadecimal-encoded 'StrictByteString' to a 'PublicKey'
+-- using the default copying decoder.
+--
+-- @since 0.0.3.0
+decodePublicKeyHexByteString :: StrictByteString -> Either KeyMaterialDecodeError PublicKey
+decodePublicKeyHexByteString = decodeHexByteString @PublicKey
+
+-- | Encode an 'PublicKey' to a hexadecimal encoded 'StrictByteString'
+-- using the default copying encoder.
+--
+-- @since 0.0.3.0
+encodePublicKeyHexByteString :: PublicKey -> StrictByteString
+encodePublicKeyHexByteString = encodeHexByteString @PublicKey
+
+-- | A public key uses a pointer of size 'cryptoSignPublicKeyBytes'.
+--
+-- @since 0.0.3.0
+instance KeyPointerSize PublicKey where
+  keyPointerSize = cryptoSignPublicKeyBytes
+
+-- | Hexadecimal-encoded bytes.
+--
+-- @since 0.0.3.0
+instance Show PublicKey where
+  show = showHexEncoding
+
+-- | A secret key of size 'cryptoSignSecretKeyBytes'. Keep this private.
+newtype SecretKey = SecretKey (ForeignPtr CUChar)
+  deriving
+    ( Eq
+      -- ^ @since 0.0.1.0
+      -- By constant-time pointer content comparison.
+    )
+    via (KeyPointer SecretKey ConstantTime)
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+      -- > display secretKey == "[REDACTED]"
+    )
+    via (OpaqueInstance "[REDACTED]" SecretKey)
+
+-- | Decode a hexadecimal-encoded 'StrictByteString' to a 'SecretKey'
+-- using the default copying decoder.
+--
+-- @since 0.0.3.0
+decodeSecretKeyHexByteString :: StrictByteString -> Either KeyMaterialDecodeError SecretKey
+decodeSecretKeyHexByteString = decodeHexByteString @SecretKey
+
+-- | Encode an 'UnsafeSecretKey' to a hexadecimal encoded
+-- 'StrictByteString' using the default copying encoder.
+--
+-- @since 0.0.3.0
+encodeSecretKeyHexByteString :: UnsafeSecretKey -> StrictByteString
+encodeSecretKeyHexByteString = encodeHexByteString @UnsafeSecretKey
+
+-- | Produce the t'PublicKey' from a t'SecretKey'.
+--
+-- This function may throw a t'PublicKeyExtractionException' if the operation fails.
+publicKey :: SecretKey -> PublicKey
+publicKey (SecretKey secretKeyPtr) = unsafeDupablePerformIO $ do
+  publicKeyPtr <- keyPointer @PublicKey
+  res <-
+    useM $
+      cryptoSignED25519SkToPk
+        <$> foreignPtr publicKeyPtr
+        <*> foreignPtr secretKeyPtr
+  unless (res == 0) $ throw PublicKeyExtractionException
+  pure $ PublicKey publicKeyPtr
+
+-- | A secret key uses a pointer of size 'cryptoSignSecretKeyBytes'.
+--
+-- @since 0.0.3.0
+instance KeyPointerSize SecretKey where
+  keyPointerSize = cryptoSignSecretKeyBytes
+
+-- | > show secretKey == "[REDACTED]"
+--
+-- @since 0.0.3.0
+instance Show SecretKey where
+  show _ = "[REDACTED]"
+
+-- | Signal your intent to encode secret key material for transmission
+-- by wrapping a t'SecretKey' in t'UnsafeSecretKey'.
+--
+-- @since 0.0.3.0
+newtype UnsafeSecretKey = UnsafeSecretKey SecretKey
+  deriving newtype
+    ( Eq
+      -- ^ @since 0.0.3.0
+      -- Follows the t'SecretKey' instance.
+    , KeyPointerSize
+      -- ^ @since 0.0.3.0
+      -- Follows the t'SecretKey' instance.
+    )
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+      -- Hexadecimal-encoded bytes.
+    )
+    via (ShowInstance UnsafeSecretKey)
+
+-- | Hexadecimal-encoded bytes.
+--
+-- @since 0.0.3.0
+instance Show UnsafeSecretKey where
+  show = showHexEncoding
+
+-- | By lexicographical comparison of pointer contents.
+--
+-- ⚠️ Vulnerable to timing attacks!
+--
+-- @since 0.0.3.0
+deriving via (KeyPointer SecretKey ShortCircuiting) instance Ord UnsafeSecretKey
+
+-- | A signing key pair, comprising a t'PublicKey' and a t'SecretKey'.
+--
+-- @since 0.0.3.0
+data KeyPair = KeyPair {public :: PublicKey, secret :: SecretKey}
+  deriving stock
+    ( Show
+      -- ^ @since 0.0.3.0
+      -- Follows the instances for t'PublicKey' and t'SecretKey', respectively.
+      --
+      -- In particular, the secret key will be shown as @[REDACTED]@.
+    , Eq
+      -- ^ @since 0.0.3.0
+      -- Follows the instances for t'PublicKey' and t'SecretKey', respectively.
+    )
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+      -- Follows the instances for t'PublicKey' and t'SecretKey', respectively.
+      --
+      -- In particular, the secret key will be displayed as @[REDACTED]@.
+    )
+    via (ShowInstance KeyPair)
+
+-- | By lexicographical comparison of key pointer contents.
+--
+-- ⚠️ Vulnerable to timing attacks!
+--
+-- @since 0.0.3.0
+instance Ord KeyPair where
+  compare kp1 kp2 =
+    compare kp1.public kp2.public
+      <> comparing UnsafeSecretKey kp1.secret kp2.secret
+
+-- | The t'PublicKey' in a t'KeyPair'.
+--
+-- @since 0.0.3.0
+public :: KeyPair -> PublicKey
+public = (.public)
+
+-- | The t'SecretKey' in a t'KeyPair'.
+--
+-- @since 0.0.3.0
+secret :: KeyPair -> SecretKey
+secret = (.secret)
+
+-- | Generate a fresh t'KeyPair'.
+--
+-- @since 0.0.3.0
+keyPair :: IO KeyPair
+keyPair = do
+  publicKeyPtr <- keyPointer @PublicKey
+  secretKeyPtr <- keyPointer @SecretKey
+  useM_ $ cryptoSignKeyPair <$> foreignPtr publicKeyPtr <*> foreignPtr secretKeyPtr
+  pure $ KeyPair (PublicKey publicKeyPtr) (SecretKey secretKeyPtr)
+
+-- | A message of known length together with its signature of length
+-- 'cryptoSignBytes'.
+--
+-- @since 0.0.1.0
+data SignedMessage = SignedMessage
+  { messageLength :: CSize
+  -- ^ Original message length
+  , messageForeignPtr :: ForeignPtr CUChar
+  , signatureForeignPtr :: ForeignPtr CUChar
+  }
+
+-- | > show message = "SignedMessage { message = \"<contents>\", signature = \"<signature>\" }"
+--
+-- @since 0.0.3.0
+instance Show SignedMessage where
+  show (SignedMessage len msg sig) = unsafeDupablePerformIO $ do
+    messageShow <- foreignPtrShow msg len
+    signatureShow <- foreignPtrShow sig cryptoSignBytes
+    pure $
+      mconcat
+        [ "SignedMessage { message = \""
+        , messageShow
+        , "\", signature = \""
+        , signatureShow
+        , "\" }"
+        ]
+
+-- | By message length, then lexicographical comparison of message and
+-- signature pointer contents.
+--
+-- @since 0.0.1.0
+instance Eq SignedMessage where
+  (SignedMessage len1 msg1 sig1) == (SignedMessage len2 msg2 sig2) =
+    unsafeDupablePerformIO $ do
+      messageEq <- foreignPtrEq msg1 msg2 len1
+      signatureEq <- foreignPtrEq sig1 sig2 cryptoSignBytes
+      pure $ (len1 == len2) && messageEq && signatureEq
+
+-- | By message length, then lexicographical comparison of message and
+-- signature pointer contents.
+--
+-- @since 0.0.1.0
+instance Ord SignedMessage where
+  compare (SignedMessage len1 msg1 sig1) (SignedMessage len2 msg2 sig2) =
+    unsafeDupablePerformIO $ do
+      messageOrder <- foreignPtrOrd msg1 msg2 len1
+      signatureOrder <- foreignPtrOrd sig1 sig2 cryptoSignBytes
+      pure $ compare len1 len2 <> messageOrder <> signatureOrder
+
+-- | Sign a message with a t'SecretKey'.
+sign :: SecretKey -> StrictByteString -> Scoped IO SignedMessage
+sign (SecretKey secretKeyForeignPtr) message = do
+  (cstring, messageLength) <- unsafeCStringLen message
+  messageForeignPtr <- mallocForeignPtrBytes messageLength
+  signatureForeignPtr <- mallocForeignPtrBytes (fromIntegral @CSize @Int cryptoSignBytes)
+  reset $ do
+    messagePtr <- foreignPtr messageForeignPtr
+    copyArray messagePtr (Foreign.castPtr @CChar @CUChar cstring) messageLength
+    signaturePtr <- foreignPtr signatureForeignPtr
+    secretKeyPtr <- foreignPtr secretKeyForeignPtr
+    lift $
+      cryptoSignDetached
+        signaturePtr
+        Foreign.nullPtr
+        (Foreign.castPtr @CChar @CUChar cstring)
+        (fromIntegral @Int @CULLong messageLength)
+        secretKeyPtr
+  pure
+    SignedMessage
+      { messageLength = fromIntegral @Int @CSize messageLength
+      , messageForeignPtr
+      , signatureForeignPtr
+      }
+
+-- | Result of detached signature verification.
+--
+-- @since 0.0.3.0
+data SignatureVerification a
+  = -- | The signature was created by the expected t'SecretKey'.
+    --
+    -- @since 0.0.3.0
+    Valid a
+  | -- | The signature was not created by the expected t'SecretKey'.
+    --
+    -- @since 0.0.3.0
+    Invalid
+  deriving stock
+    ( Eq
+      -- ^ @since 0.0.3.0
+    , Ord
+      -- ^ @since 0.0.3.0
+    , Show
+      -- ^ @since 0.0.3.0
+    , Functor
+      -- ^ @since 0.0.3.0
+    , Foldable
+      -- ^ @since 0.0.3.0
+    , Traversable
+      -- ^ @since 0.0.3.0
+    )
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+    )
+    via (ShowInstance (SignatureVerification a))
+
+-- | Verify that a message was signed by the t'SecretKey' corresponding
+-- to the given t'PublicKey'.
+--
+-- @since 0.0.3.0
+verify :: SignedMessage -> PublicKey -> Scoped IO (SignatureVerification SignedMessage)
+verify message (PublicKey publicKeyForeignPtr) = do
+  result <- reset $ do
+    publicKeyPtr <- foreignPtr publicKeyForeignPtr
+    signaturePtr <- foreignPtr message.signatureForeignPtr
+    messagePtr <- foreignPtr message.messageForeignPtr
+    lift $
+      cryptoSignVerifyDetached
+        signaturePtr
+        messagePtr
+        (fromIntegral @CSize @CULLong message.messageLength)
+        publicKeyPtr
+  pure $ if result == 0 then Valid message else Invalid
+
+-- | Attempt to extract the message from a t'SignedMessage', verifying
+-- that the message was signed with the t'SecretKey' corresponding to
+-- the given t'PublicKey'.
+--
+-- @since 0.0.3.0
+open :: SignedMessage -> PublicKey -> Scoped IO (SignatureVerification StrictByteString)
+open message key = traverse extractUnverifiedMessage =<< verify message key
+
+-- | Extract a part of a t'SignedMessage' without verifying the signature.
+--
+-- @since 0.0.3.0
+unverifiedExtract
+  :: (SignedMessage -> ForeignPtr CUChar)
+  -> CSize
+  -> SignedMessage
+  -> Scoped IO StrictByteString
+unverifiedExtract target fieldLength (target -> field) = do
+  fieldPtr <- foreignPtr field
+  bsPtr <- mallocBytes (fromIntegral fieldLength)
+  lift $ Foreign.copyBytes bsPtr fieldPtr (fromIntegral fieldLength)
+  lift $ do
+    ByteString.unsafePackMallocCStringLen
+      ( Foreign.castPtr @_ @CChar bsPtr
+      , fromIntegral fieldLength
+      )
+
+-- | Extract the message part of a t'SignedMessage' without verifying the signature.
+--
+-- @since 0.0.3.0
+extractUnverifiedMessage :: SignedMessage -> Scoped IO StrictByteString
+extractUnverifiedMessage msg = unverifiedExtract (.messageForeignPtr) msg.messageLength msg
+
+-- | Extract the signature part of a t'SignedMessage' without verifying the signature.
+--
+-- @since 0.0.3.0
+extractSignature :: SignedMessage -> Scoped IO StrictByteString
+extractSignature = unverifiedExtract (.signatureForeignPtr) cryptoSignBytes
+
+-- | Construct a t'SignedMessage' from the message contents and a detached signature.
+--
+-- @since 0.0.3.0
+buildSignedMessage :: StrictByteString -> StrictByteString -> Scoped IO SignedMessage
+buildSignedMessage message signature = do
+  (messageString, messageLength) <- unsafeCStringLen message
+  messageForeignPtr <- mallocForeignPtrBytes messageLength
+  signatureForeignPtr <- mallocForeignPtrBytes (fromIntegral cryptoSignBytes)
+  reset $ do
+    signatureString <- unsafeCString signature
+    messagePtr <- foreignPtr messageForeignPtr
+    signaturePtr <- foreignPtr signatureForeignPtr
+    copyArray messagePtr (Foreign.castPtr messageString) messageLength
+    copyArray signaturePtr (Foreign.castPtr signatureString) (fromIntegral cryptoSignBytes)
+  pure
+    SignedMessage
+      { messageLength = fromIntegral @Int @CSize messageLength
+      , messageForeignPtr
+      , signatureForeignPtr
+      }
+
+-- | Thrown when we fail to extract a t'PublicKey' from a t'SecretKey'.
+--
+-- @since 0.0.3.0
+data PublicKeyExtractionException = PublicKeyExtractionException
+  deriving stock
+    ( Eq
+      -- ^ @since 0.0.3.0
+    , Ord
+      -- ^ @since 0.0.3.0
+    , Show
+      -- ^ @since 0.0.3.0
+    )
+  deriving anyclass
+    ( Exception
+      -- ^ @since 0.0.3.0
+    )

--- a/sel/src/Sel/PublicKey/Seal.hs
+++ b/sel/src/Sel/PublicKey/Seal.hs
@@ -38,11 +38,21 @@ import Data.ByteString (StrictByteString)
 import qualified Data.ByteString.Unsafe as BS
 import qualified Foreign
 import Foreign.C (CChar, CSize, CUChar, CULLong)
-import GHC.IO.Handle.Text (memcpy)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
-import LibSodium.Bindings.SealedBoxes (cryptoBoxSeal, cryptoBoxSealOpen, cryptoBoxSealbytes)
-import Sel.PublicKey.Cipher (CipherText (CipherText), EncryptionError (..), KeyPairGenerationException, PublicKey (PublicKey), SecretKey (..), newKeyPair)
+import LibSodium.Bindings.SealedBoxes
+  ( cryptoBoxSeal
+  , cryptoBoxSealOpen
+  , cryptoBoxSealbytes
+  )
+import Sel.PublicKey.Cipher
+  ( CipherText (CipherText)
+  , EncryptionError (..)
+  , KeyPairGenerationException
+  , PublicKey (PublicKey)
+  , SecretKey (..)
+  , newKeyPair
+  )
 
 -- $introduction
 -- Ephemeral authenticated encryption allows to anonymously send message to
@@ -133,7 +143,7 @@ open
             (-1) -> pure Nothing
             _ -> do
               bsPtr <- Foreign.mallocBytes (fromIntegral messageLen)
-              memcpy bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLen)
+              Foreign.copyBytes bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLen)
               Just
                 <$> BS.unsafePackMallocCStringLen
-                  (Foreign.castPtr @CChar bsPtr, fromIntegral messageLen)
+                  (Foreign.castPtr @CUChar @CChar bsPtr, fromIntegral messageLen)

--- a/sel/src/Sel/PublicKey/Signature.hs
+++ b/sel/src/Sel/PublicKey/Signature.hs
@@ -1,40 +1,57 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-
 -- |
 --
 -- Module: Sel.PublicKey.Signature
 -- Description: Public-key signatures with the Ed25519 algorithm
--- Copyright: (C) Hécate Moonlight 2022
+-- Copyright: (C) Hécate Moonlight 2022, Jack Henahan 2024
 -- License: BSD-3-Clause
 -- Maintainer: The Haskell Cryptography Group
 -- Portability: GHC only
 module Sel.PublicKey.Signature
-  ( -- ** Introduction
+  ( -- * Public-key Signatures
     -- $introduction
 
-    -- ** Public and Secret keys
+    -- ** Public keys
+    -- $publicKeys
     PublicKey
-  , publicKeyToHexByteString
-  , publicKeyFromHexByteString
-  , publicKeyFromSecretKey
+  , decodePublicKeyHexByteString
+  , encodePublicKeyHexByteString
+
+    -- ** Secret keys
+    -- $secretKeys
   , SecretKey
-  , unsafeSecretKeyToHexByteString
-  , secretKeyFromHexByteString
-  , SignedMessage
+  , decodeSecretKeyHexByteString
+  , encodeSecretKeyHexByteString
+  , publicKey
+
+    -- *** ⚠️ Handle with care
+  , UnsafeSecretKey (..)
+  , unsafeSecretKeyHexByteString
 
     -- ** Key Pair generation
+  , KeyPair (..)
+  , public
+  , secret
+  , keyPair
+
+    -- *** Deprecated functions
   , generateKeyPair
 
     -- ** Message Signing
+  , SignedMessage
+  , signWith
   , signMessage
-  , openMessage
 
-    -- ** Constructing and Deconstructing signatures
+    -- *** Inspecting signed messages
+  , verifiedMessage
+  , SignatureVerification (..)
+  , signature
+  , unverifiedMessage
+
+    -- *** Detached signatures
+  , signedMessage
+
+    -- *** Deprecated functions
+  , openMessage
   , getSignature
   , unsafeGetMessage
   , mkSignature
@@ -44,372 +61,175 @@ module Sel.PublicKey.Signature
   )
 where
 
-import Control.Monad (void, when)
-import qualified Data.Base16.Types as Base16
 import Data.ByteString (StrictByteString)
-import qualified Data.ByteString as ByteString
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.ByteString.Internal as ByteString
-import qualified Data.ByteString.Unsafe as ByteString
-import Data.Text.Display (Display, OpaqueInstance (..), ShowInstance (..))
-import Foreign
-  ( ForeignPtr
-  , Ptr
-  , Word8
-  , castPtr
-  , mallocBytes
-  , mallocForeignPtrBytes
-  , withForeignPtr
-  )
-import qualified Foreign
-import Foreign.C (CChar, CSize, CUChar, CULLong, throwErrno)
-import GHC.IO.Handle.Text (memcpy)
+import Sel.Internal.Scoped (use)
+import Sel.PublicKey.Internal.Signature
 import System.IO.Unsafe (unsafeDupablePerformIO)
-
-import Control.Exception (Exception, throw)
-import Data.Text (Text)
-import qualified Data.Text as Text
-import LibSodium.Bindings.CryptoSign
-  ( cryptoSignBytes
-  , cryptoSignDetached
-  , cryptoSignED25519SkToPk
-  , cryptoSignKeyPair
-  , cryptoSignPublicKeyBytes
-  , cryptoSignSecretKeyBytes
-  , cryptoSignVerifyDetached
-  )
-import LibSodium.Bindings.SecureMemory (finalizerSodiumFree, sodiumMalloc)
-import Sel.Internal
 
 -- $introduction
 --
--- Public-key Signatures work with a 'SecretKey' and 'PublicKey'
+-- Append a signature to any number of messages using a
+-- t'SecretKey'. Distribute a t'PublicKey' so third-parties can verify
+-- that the messages were signed with a particular t'SecretKey'.
 --
--- * The 'SecretKey' is used to append a signature to any number of messages. It must stay private;
--- * The 'PublicKey' is used by third-parties to to verify that the signature appended to a message was
--- issued by the creator of the public key. It must be distributed to third-parties.
+-- * The t'SecretKey' must stay private.
 --
--- Verifiers need to already know and ultimately trust a public key before messages signed
--- using it can be verified.
+-- * The t'PublicKey' is not a proof of identity, only control. Ensure
+-- that t'PublicKey's are trusted before verifying signatures.
 
--- | A public key of size 'cryptoSignPublicKeyBytes'.
+-- $publicKeys
 --
--- @since 0.0.1.0
-newtype PublicKey = PublicKey (ForeignPtr CUChar)
-  deriving
-    ( Display
-      -- ^ @since 0.0.2.0
-    )
-    via (ShowInstance PublicKey)
+-- Public keys are intended to be shared with any party or process
+-- which may need to verify that a given message was signed by a
+-- particular secret key.
+--
+-- === Human-readable output
+--
+-- * @'Data.Text.Display.display' :: t'PublicKey' -> 'Data.Text.Text'@, the hexadecimal encoding of the t'PublicKey' in a 'Data.Text.Text'
+-- * @'show' :: t'PublicKey' -> 'String'@, the hexadecimal encoding of the t'PublicKey' in a 'String'
 
--- |
+-- $secretKeys
 --
--- @since 0.0.1.0
-instance Eq PublicKey where
-  (PublicKey pk1) == (PublicKey pk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq pk1 pk2 cryptoSignPublicKeyBytes
+-- Secret keys are intended to be private and never shared without
+-- extreme care. Leaking a secret key allows anyone to impersonate the
+-- creator of that key and sign messages with their identity.
+--
+-- If a secret key is compromised, all messages signed by that key
+-- should be considered compromised.
+--
+-- Secret keys are compared for equality using the constant-time
+-- 'LibSodium.Bindings.Comparison.sodiumMemcmp' to avoid timing attacks.
+--
+-- __NB:__ Prefer being explicit with t'UnsafeSecretKey' to signal your
+-- intent to transmit sensitive key material.
+--
+-- === ⚠️ Serialization
+--
+-- * @'encodeSecretKeyHexByteString' :: t'UnsafeSecretKey' -> 'StrictBytestring'@
+-- * @'unsafeSecretKeyHexByteString' :: t'SecretKey' -> 'StrictByteString'@
+--
+-- === ⚠️ Human-readable output
+--
+-- * @'Text.Display.display' :: t'UnsafeSecretKey' -> 'Data.Text.Text'@, the hexadecimal encoding of the wrapped t'SecretKey' in a 'Data.Text.Text'
+-- * @'show' :: t'UnsafeSecretKey' -> 'String'@, the hexadecimal encoding of the wrapped t'SecretKey' in a 'String'
 
--- |
+-- | Convert a t'SecretKey' to a hexadecimal-encoded 'StrictByteString'.
 --
--- @since 0.0.1.0
-instance Ord PublicKey where
-  compare (PublicKey pk1) (PublicKey pk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd pk1 pk2 cryptoSignPublicKeyBytes
+-- ⚠️ Serializing secret keys is a security risk. Be careful how you
+-- use the output of this function.
+--
+-- @since 0.0.3.0
+unsafeSecretKeyHexByteString :: SecretKey -> StrictByteString
+unsafeSecretKeyHexByteString = encodeSecretKeyHexByteString . UnsafeSecretKey
 
--- |
+-- | Sign a message with a t'SecretKey'.
 --
--- @since 0.0.2.0
-instance Show PublicKey where
-  show = ByteString.unpackChars . publicKeyToHexByteString
+-- === Example
+--
+-- Given @messages :: 'Traversable' t => t 'StrictByteString'@ and
+-- @key :: t'SecretKey'@, we can sign each message with our key.
+--
+-- @
+--   traverse (signWith key) messages -- :: Traversable t => IO (t SignedMessage)
+--   -- or, equivalently
+--   for messages (signWith key)
+-- @
+--
+-- @since 0.0.3.0
+signWith :: SecretKey -> StrictByteString -> IO SignedMessage
+signWith secretKey message = use $ sign secretKey message
 
--- | Convert a 'PublicKey' to a hexadecimal-encoded 'StrictByteString'.
+-- | Sign a message with a t'SecretKey'.
 --
--- @since 0.0.2.0
-publicKeyToHexByteString :: PublicKey -> StrictByteString
-publicKeyToHexByteString (PublicKey publicKeyForeignPtr) =
-  Base16.extractBase16 . Base16.encodeBase16' $
-    ByteString.fromForeignPtr0
-      (Foreign.castForeignPtr @CUChar @Word8 publicKeyForeignPtr)
-      (fromIntegral @CSize @Int cryptoSignPublicKeyBytes)
-
--- | Create a 'PublicKey' from a binary 'StrictByteString' that you have obtained on your own,
--- usually from the network or disk.
+-- === Example
 --
--- The input public key, once decoded from base16, must be of length
--- 'cryptoSignKeyBytes'.
+-- Given @keys :: 'Traversable' t => t t'SecretKey'@ and @message ::
+-- 'StrictByteString'@, we can sign our message with each key.
 --
--- @since 0.0.1.0
-publicKeyFromHexByteString :: StrictByteString -> Either Text PublicKey
-publicKeyFromHexByteString hexNonce = unsafeDupablePerformIO $
-  case Base16.decodeBase16Untyped hexNonce of
-    Right bytestring ->
-      if ByteString.length bytestring == fromIntegral cryptoSignPublicKeyBytes
-        then ByteString.unsafeUseAsCStringLen bytestring $ \(outsidePublicKeyPtr, _) ->
-          fmap Right $
-            newPublicKeyWith $ \publicKeyPtr ->
-              Foreign.copyArray
-                (Foreign.castPtr @CUChar @CChar publicKeyPtr)
-                outsidePublicKeyPtr
-                (fromIntegral cryptoSignPublicKeyBytes)
-        else pure $ Left $ Text.pack "Public Key is too short"
-    Left msg -> pure $ Left msg
-
--- | Produce the 'PublicKey' from a 'SecretKey'.
---
--- This function may throw a 'PublicKeyExtractionException' if the operation fails.
---
--- @since 0.0.2.0
-publicKeyFromSecretKey :: SecretKey -> PublicKey
-publicKeyFromSecretKey (SecretKey secretKeyForeignPtr) = unsafeDupablePerformIO $ do
-  publicKeyForeignPtr <- mallocForeignPtrBytes (fromIntegral @CSize @Int cryptoSignPublicKeyBytes)
-  withForeignPtr publicKeyForeignPtr $ \pkPtr ->
-    withForeignPtr secretKeyForeignPtr $ \skPtr -> do
-      result <-
-        cryptoSignED25519SkToPk
-          pkPtr
-          skPtr
-      when (result /= 0) $ throw PublicKeyExtractionException
-  pure (PublicKey publicKeyForeignPtr)
-
--- | Prepare memory for a 'SecretKey' and use the provided action to fill it.
---
--- Memory is allocated with 'LibSodium.Bindings.SecureMemory.sodiumMalloc' (see the note attached there).
--- A finalizer is run when the key is goes out of scope.
---
--- @since 0.0.1.0
-newPublicKeyWith :: (Foreign.Ptr CUChar -> IO ()) -> IO PublicKey
-newPublicKeyWith action = do
-  ptr <- sodiumMalloc cryptoSignPublicKeyBytes
-  when (ptr == Foreign.nullPtr) $ do
-    throwErrno "sodium_malloc"
-  fPtr <- Foreign.newForeignPtr finalizerSodiumFree ptr
-  action ptr
-  pure $ PublicKey fPtr
-
--- | A secret key of size 'cryptoSignSecretKeyBytes'.
---
--- @since 0.0.1.0
-newtype SecretKey = SecretKey (ForeignPtr CUChar)
-  deriving
-    ( Display
-      -- ^ @since 0.0.2.0
-      -- > display secretKey == "[REDACTED]"
-    )
-    via (OpaqueInstance "[REDACTED]" SecretKey)
-
--- | > show secretKey == "[REDACTED]"
---
--- @since 0.0.2.0
-instance Show SecretKey where
-  show _ = "[REDACTED]"
-
--- |
---
--- @since 0.0.1.0
-instance Eq SecretKey where
-  (SecretKey sk1) == (SecretKey sk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq sk1 sk2 cryptoSignSecretKeyBytes
-
--- |
---
--- @since 0.0.1.0
-instance Ord SecretKey where
-  compare (SecretKey sk1) (SecretKey sk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd sk1 sk2 cryptoSignSecretKeyBytes
-
--- | Convert a 'SecretKey' to a hexadecimal-encoded 'StrictByteString'.
---
--- ⚠️  Be prudent as to where you store it!
---
--- @since 0.0.2.0
-unsafeSecretKeyToHexByteString :: SecretKey -> StrictByteString
-unsafeSecretKeyToHexByteString (SecretKey secretKeyForeignPtr) =
-  Base16.extractBase16 . Base16.encodeBase16' $
-    ByteString.fromForeignPtr0
-      (Foreign.castForeignPtr @CUChar @Word8 secretKeyForeignPtr)
-      (fromIntegral @CSize @Int cryptoSignSecretKeyBytes)
-
--- | Create a 'SecretKey' from a binary 'StrictByteString' that you have obtained on your own,
--- usually from the network or disk.
---
--- The input secret key, once decoded from base16, must be of length
--- 'cryptoSignKeyBytes'.
---
--- @since 0.0.1.0
-secretKeyFromHexByteString :: StrictByteString -> Either Text SecretKey
-secretKeyFromHexByteString hexNonce = unsafeDupablePerformIO $
-  case Base16.decodeBase16Untyped hexNonce of
-    Right bytestring ->
-      if ByteString.length bytestring == fromIntegral cryptoSignSecretKeyBytes
-        then ByteString.unsafeUseAsCStringLen bytestring $ \(outsideSecretKeyPtr, _) ->
-          fmap Right $
-            newSecretKeyWith $ \secretKeyPtr ->
-              Foreign.copyArray
-                (Foreign.castPtr @CUChar @CChar secretKeyPtr)
-                outsideSecretKeyPtr
-                (fromIntegral cryptoSignSecretKeyBytes)
-        else pure $ Left $ Text.pack "Secret Key is too short"
-    Left msg -> pure $ Left msg
-
--- | Prepare memory for a 'SecretKey' and use the provided action to fill it.
---
--- Memory is allocated with 'LibSodium.Bindings.SecureMemory.sodiumMalloc' (see the note attached there).
--- A finalizer is run when the key is goes out of scope.
---
--- @since 0.0.2.0
-newSecretKeyWith :: (Foreign.Ptr CUChar -> IO ()) -> IO SecretKey
-newSecretKeyWith action = do
-  ptr <- sodiumMalloc cryptoSignSecretKeyBytes
-  when (ptr == Foreign.nullPtr) $ do
-    throwErrno "sodium_malloc"
-  fPtr <- Foreign.newForeignPtr finalizerSodiumFree ptr
-  action ptr
-  pure $ SecretKey fPtr
-
--- | A message and its signature.
--- The signature is of length 'cryptoSignBytes'.
---
--- @since 0.0.1.0
-data SignedMessage = SignedMessage
-  { messageLength :: CSize
-  -- ^ Original message length
-  , messageForeignPtr :: ForeignPtr CUChar
-  , signatureForeignPtr :: ForeignPtr CUChar
-  }
-
--- |
---
--- @since 0.0.1.0
-instance Eq SignedMessage where
-  (SignedMessage len1 msg1 sig1) == (SignedMessage len2 msg2 sig2) =
-    unsafeDupablePerformIO $ do
-      result1 <- foreignPtrEq msg1 msg2 len1
-      result2 <- foreignPtrEq sig1 sig2 cryptoSignBytes
-      return $ (len1 == len2) && result1 && result2
-
--- |
---
--- @since 0.0.1.0
-instance Ord SignedMessage where
-  compare (SignedMessage len1 msg1 sig1) (SignedMessage len2 msg2 sig2) =
-    unsafeDupablePerformIO $ do
-      result1 <- foreignPtrOrd msg1 msg2 len1
-      result2 <- foreignPtrOrd sig1 sig2 cryptoSignBytes
-      return $ compare len1 len2 <> result1 <> result2
-
--- | Generate a pair of public and secret key.
---
--- The length parameters used are 'cryptoSignPublicKeyBytes'
--- and 'cryptoSignSecretKeyBytes'.
---
--- @since 0.0.1.0
-generateKeyPair :: IO (PublicKey, SecretKey)
-generateKeyPair = do
-  publicKeyForeignPtr <- mallocForeignPtrBytes (fromIntegral @CSize @Int cryptoSignPublicKeyBytes)
-  secretKeyForeignPtr <- mallocForeignPtrBytes (fromIntegral @CSize @Int cryptoSignSecretKeyBytes)
-  withForeignPtr publicKeyForeignPtr $ \pkPtr ->
-    withForeignPtr secretKeyForeignPtr $ \skPtr ->
-      void $
-        cryptoSignKeyPair
-          pkPtr
-          skPtr
-  pure (PublicKey publicKeyForeignPtr, SecretKey secretKeyForeignPtr)
-
--- | Sign a message.
+-- @
+--   traverse (signMessage message) keys -- :: Traversable t => IO (t 'SignedMessage')
+--   -- or, equivalently
+--   for keys (signMessage message)
+-- @
 --
 -- @since 0.0.1.0
 signMessage :: StrictByteString -> SecretKey -> IO SignedMessage
-signMessage message (SecretKey skFPtr) =
-  ByteString.unsafeUseAsCStringLen message $ \(cString, messageLength) -> do
-    let sigLength = fromIntegral @CSize @Int cryptoSignBytes
-    (messageForeignPtr :: ForeignPtr CUChar) <- Foreign.mallocForeignPtrBytes messageLength
-    signatureForeignPtr <- Foreign.mallocForeignPtrBytes sigLength
-    withForeignPtr messageForeignPtr $ \messagePtr ->
-      withForeignPtr signatureForeignPtr $ \signaturePtr ->
-        withForeignPtr skFPtr $ \skPtr -> do
-          Foreign.copyArray messagePtr (Foreign.castPtr @CChar @CUChar cString) messageLength
-          void $
-            cryptoSignDetached
-              signaturePtr
-              Foreign.nullPtr -- Always of size 'cryptoSignBytes'
-              (castPtr @CChar @CUChar cString)
-              (fromIntegral @Int @CULLong messageLength)
-              skPtr
-    pure $ SignedMessage (fromIntegral @Int @CSize messageLength) messageForeignPtr signatureForeignPtr
+signMessage = flip signWith
 
--- | Open a signed message with the signatory's public key.
--- The function returns 'Nothing' if there is a key mismatch.
+-- | Attempt to extract the message from a t'SignedMessage', verifying
+-- that the message was signed with the t'SecretKey' corresponding to
+-- the given t'PublicKey'.
+--
+-- @since 0.0.3.0
+verifiedMessage :: SignedMessage -> PublicKey -> SignatureVerification StrictByteString
+verifiedMessage message key = unsafeDupablePerformIO . use $ open message key
+
+-- | Get the signature part of a t'SignedMessage'.
+--
+-- @since 0.0.3.0
+signature :: SignedMessage -> StrictByteString
+signature = unsafeDupablePerformIO . use . extractSignature
+
+-- | Get the message part of a t'SignedMessage' __without verifying the signature__.
+--
+-- @since 0.0.3.0
+unverifiedMessage :: SignedMessage -> StrictByteString
+unverifiedMessage = unsafeDupablePerformIO . use . extractUnverifiedMessage
+
+-- | Construct a signed message from a message and a detached signature.
+--
+-- @since 0.0.3.0
+signedMessage :: StrictByteString -> StrictByteString -> SignedMessage
+signedMessage messageBytes signatureBytes =
+  unsafeDupablePerformIO . use $
+    buildSignedMessage messageBytes signatureBytes
+
+{- Deprecated API -}
+
+{- KeyPair -}
+{-# DEPRECATED generateKeyPair "Prefer 'keyPair'" #-}
+
+-- | Generate a pair of public and secret key.
+--
+-- The length parameters used are 'LibSodium.Bindings.CryptoSign.cryptoSignPublicKeyBytes'
+-- and 'LibSodium.Bindings.CryptoSign.cryptoSignSecretKeyBytes'.
+--
+-- @since 0.0.1.0
+generateKeyPair :: IO (PublicKey, SecretKey)
+generateKeyPair = (,) <$> public <*> secret <$> keyPair
+
+{- SignedMessage -}
+{-# DEPRECATED openMessage "Prefer 'verifiedMessage'" #-}
+{-# DEPRECATED getSignature "Prefer 'signature'" #-}
+{-# DEPRECATED unsafeGetMessage "Prefer 'unverifiedMessage'" #-}
+{-# DEPRECATED mkSignature "Prefer 'signedMessage'" #-}
+
+-- | Attempt to extract a the message from a t'SignedMessage',
+-- verifying that the message was signed with the t'SecretKey'
+-- corresponding to the given t'PublicKey', yielding `Nothing` if the
+-- key is not applicable.
 --
 -- @since 0.0.1.0
 openMessage :: SignedMessage -> PublicKey -> Maybe StrictByteString
-openMessage SignedMessage{messageLength, messageForeignPtr, signatureForeignPtr} (PublicKey pkForeignPtr) = unsafeDupablePerformIO $
-  withForeignPtr pkForeignPtr $ \publicKeyPtr ->
-    withForeignPtr signatureForeignPtr $ \signaturePtr -> do
-      withForeignPtr messageForeignPtr $ \messagePtr -> do
-        result <-
-          cryptoSignVerifyDetached
-            signaturePtr
-            messagePtr
-            (fromIntegral @CSize @CULLong messageLength)
-            publicKeyPtr
-        case result of
-          (-1) -> pure Nothing
-          _ -> do
-            bsPtr <- mallocBytes (fromIntegral messageLength)
-            memcpy bsPtr (castPtr messagePtr) messageLength
-            Just <$> ByteString.unsafePackMallocCStringLen (castPtr bsPtr :: Ptr CChar, fromIntegral messageLength)
+openMessage message key =
+  case verifiedMessage message key of
+    Valid msg -> Just msg
+    Invalid -> Nothing
 
--- | Get the signature part of a 'SignedMessage'.
+-- | Get the signature part of a t'SignedMessage'.
 --
 -- @since 0.0.1.0
 getSignature :: SignedMessage -> StrictByteString
-getSignature SignedMessage{signatureForeignPtr} = unsafeDupablePerformIO $
-  withForeignPtr signatureForeignPtr $ \signaturePtr -> do
-    bsPtr <- Foreign.mallocBytes (fromIntegral cryptoSignBytes)
-    memcpy bsPtr signaturePtr cryptoSignBytes
-    ByteString.unsafePackMallocCStringLen (Foreign.castPtr bsPtr :: Ptr CChar, fromIntegral cryptoSignBytes)
+getSignature = signature
 
--- | Get the message part of a 'SignedMessage' __without verifying the signature__.
+-- | Get the message part of a t'SignedMessage' __without verifying the signature__.
 --
 -- @since 0.0.1.0
 unsafeGetMessage :: SignedMessage -> StrictByteString
-unsafeGetMessage SignedMessage{messageLength, messageForeignPtr} = unsafeDupablePerformIO $
-  withForeignPtr messageForeignPtr $ \messagePtr -> do
-    bsPtr <- Foreign.mallocBytes (fromIntegral messageLength)
-    memcpy bsPtr messagePtr messageLength
-    ByteString.unsafePackMallocCStringLen (Foreign.castPtr bsPtr :: Ptr CChar, fromIntegral messageLength)
+unsafeGetMessage = unverifiedMessage
 
--- | Combine a message and a signature into a 'SignedMessage'.
+-- | Construct a signed message from a message and a detached signature.
 --
 -- @since 0.0.1.0
 mkSignature :: StrictByteString -> StrictByteString -> SignedMessage
-mkSignature message signature = unsafeDupablePerformIO $
-  ByteString.unsafeUseAsCStringLen message $ \(messageStringPtr, messageLength) ->
-    ByteString.unsafeUseAsCStringLen signature $ \(signatureStringPtr, _) -> do
-      (messageForeignPtr :: ForeignPtr CUChar) <- Foreign.mallocForeignPtrBytes messageLength
-      signatureForeignPtr <- Foreign.mallocForeignPtrBytes (fromIntegral cryptoSignBytes)
-      withForeignPtr messageForeignPtr $ \messagePtr ->
-        withForeignPtr signatureForeignPtr $ \signaturePtr -> do
-          Foreign.copyArray messagePtr (Foreign.castPtr messageStringPtr) messageLength
-          Foreign.copyArray signaturePtr (Foreign.castPtr signatureStringPtr) (fromIntegral cryptoSignBytes)
-      pure $ SignedMessage (fromIntegral @Int @CSize messageLength) messageForeignPtr signatureForeignPtr
-
--- |
--- @since 0.0.2.0
-data PublicKeyExtractionException = PublicKeyExtractionException
-  deriving stock
-    ( Eq
-      -- ^ @since 0.0.2.0
-    , Ord
-      -- ^ @since 0.0.2.0
-    , Show
-      -- ^ @since 0.0.2.0
-    )
-  deriving anyclass
-    ( Exception
-      -- ^ @since 0.0.2.0
-    )
+mkSignature = signedMessage

--- a/sel/src/Sel/Scrypt.hs
+++ b/sel/src/Sel/Scrypt.hs
@@ -37,7 +37,7 @@ import qualified Data.Text.Lazy.Builder as Builder
 import Foreign hiding (void)
 import Foreign.C
 import LibSodium.Bindings.Scrypt
-import Sel.Internal
+import Sel.Internal.Instances
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
 -- $introduction
@@ -55,13 +55,13 @@ newtype ScryptHash = ScryptHash (ForeignPtr CChar)
 instance Eq ScryptHash where
   (ScryptHash sh1) == (ScryptHash sh2) =
     unsafeDupablePerformIO $
-      foreignPtrEq sh1 sh2 cryptoPWHashScryptSalsa208SHA256StrBytes
+      foreignPtrEq (Foreign.castForeignPtr sh1) (Foreign.castForeignPtr sh2) cryptoPWHashScryptSalsa208SHA256StrBytes
 
 -- | @since 0.0.1.0
 instance Ord ScryptHash where
   compare (ScryptHash sh1) (ScryptHash sh2) =
     unsafeDupablePerformIO $
-      foreignPtrOrd sh1 sh2 cryptoPWHashScryptSalsa208SHA256StrBytes
+      foreignPtrOrd (Foreign.castForeignPtr sh1) (Foreign.castForeignPtr sh2) cryptoPWHashScryptSalsa208SHA256StrBytes
 
 -- | @since 0.0.1.0
 instance Show ScryptHash where

--- a/sel/src/Sel/SecretKey/Authentication.hs
+++ b/sel/src/Sel/SecretKey/Authentication.hs
@@ -56,7 +56,7 @@ import LibSodium.Bindings.CryptoAuth
   , cryptoAuthVerify
   )
 import LibSodium.Bindings.SecureMemory
-import Sel.Internal
+import Sel.Internal.Instances
 
 -- $introduction
 -- The 'authenticate' function computes an authentication tag for a message and a secret key,

--- a/sel/src/Sel/SecretKey/Cipher.hs
+++ b/sel/src/Sel/SecretKey/Cipher.hs
@@ -57,7 +57,6 @@ import Data.Word (Word8)
 import Foreign (ForeignPtr)
 import qualified Foreign
 import Foreign.C (CChar, CSize, CUChar, CULLong, throwErrno)
-import GHC.IO.Handle.Text (memcpy)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
 import LibSodium.Bindings.Random (randombytesBuf)
@@ -70,7 +69,7 @@ import LibSodium.Bindings.Secretbox
   , cryptoSecretboxOpenEasy
   )
 import LibSodium.Bindings.SecureMemory
-import Sel.Internal
+import Sel.Internal.Instances
 
 -- $introduction
 -- "Authenticated Encryption" uses a secret key along with a single-use number
@@ -413,7 +412,7 @@ decrypt Hash{messageLength, hashForeignPtr} (SecretKey secretKeyForeignPtr) (Non
           (-1) -> pure Nothing
           _ -> do
             bsPtr <- Foreign.mallocBytes (fromIntegral messageLength)
-            memcpy bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLength)
+            Foreign.copyBytes bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLength)
             Just
               <$> BS.unsafePackMallocCStringLen
                 (Foreign.castPtr @CChar bsPtr, fromIntegral messageLength)

--- a/sel/src/Sel/SecretKey/Stream.hs
+++ b/sel/src/Sel/SecretKey/Stream.hs
@@ -104,7 +104,8 @@ import LibSodium.Bindings.SecretStream
   , cryptoSecretStreamXChaCha20Poly1305TagRekey
   )
 import LibSodium.Bindings.SecureMemory (finalizerSodiumFree, sodiumMalloc)
-import Sel.Internal (allocateWith, foreignPtrEq, foreignPtrOrd)
+import Sel.Internal
+import Sel.Internal.Instances
 
 -- $introduction
 -- This high-level API encrypts a sequence of messages, or a single message split into an arbitrary number of chunks, using a secret key, with the following properties:

--- a/sel/test/Test/PublicKey/Signature.hs
+++ b/sel/test/Test/PublicKey/Signature.hs
@@ -5,13 +5,39 @@ module Test.PublicKey.Signature where
 import Sel.PublicKey.Signature
 import Test.Tasty
 import Test.Tasty.HUnit
+import TestUtils
 
 spec :: TestTree
 spec =
   testGroup
     "Signing tests"
     [ testCase "Sign a message with a public key and decrypt it with a secret key" testSignMessage
+    , testCase "Extract the public key from a secret key" testExtractPublicKey
+    , testCase "Round-trip secret key serialisation" testSecretKeySerdeRoundtrip
+    , testCase "Round-trip public key serialisation" testPublicKeySerdeRoundtrip
     ]
+
+testSecretKeySerdeRoundtrip :: Assertion
+testSecretKeySerdeRoundtrip = do
+  (_, secretKey) <- generateKeyPair
+
+  let secretKeyByteString = unsafeSecretKeyToHexByteString secretKey
+  reconstructedSecretKey <- assertRight $ secretKeyFromHexByteString secretKeyByteString
+  assertEqual
+    "Secret key cannot be read from hex bytestring"
+    secretKey
+    reconstructedSecretKey
+
+testPublicKeySerdeRoundtrip :: Assertion
+testPublicKeySerdeRoundtrip = do
+  (publicKey, _) <- generateKeyPair
+
+  let publicKeyByteString = publicKeyToHexByteString publicKey
+  reconstructedPublicKey <- assertRight $ publicKeyFromHexByteString publicKeyByteString
+  assertEqual
+    "Public key cannot be read from hex bytestring"
+    publicKey
+    reconstructedPublicKey
 
 testSignMessage :: Assertion
 testSignMessage = do
@@ -22,3 +48,12 @@ testSignMessage = do
     "Message is well-opened with the correct key"
     (Just "hello hello")
     result
+
+testExtractPublicKey :: Assertion
+testExtractPublicKey = do
+  (publicKey, secretKey) <- generateKeyPair
+  let extractedPublicKey' = publicKeyFromSecretKey secretKey
+  assertEqual
+    "Public key extracted from Secret Key is not correct"
+    publicKey
+    extractedPublicKey'


### PR DESCRIPTION
Contains the changes from #153, along with substantial additions. Happy to break this up into multiple PRs after some review, it's just harder to motivate without the whole picture. If the style is agreeable (and CI passes happily enough), I'd like to push in a similar direction for the other modules as followup work.

Highlights:
- Adds an internal `Codensity` called `Scoped` to clean up nested CPS code
- Adds utilities for serialization and deserialization of key material, along with instance utilities and error modeling
- Adds constant-time comparison `Eq` for safety against timing attacks on secret material
- Migrates all uses of `memcpy` and `memcmp` to `Foreign.copyBytes` and `Data.ByteString.Internal.memcmp`, respectively
- Hides all the internals of `PublicKey.Signature`
- Expanded test suite for `PublicKey.Signature`
- Lots of docs