### PR TITLE
feat(Internal): add constant-time Eq, use Scoped for internals

### DIFF
--- a/sel/src/Sel/HMAC/SHA256.hs
+++ b/sel/src/Sel/HMAC/SHA256.hs
@@ -81,7 +81,7 @@ import LibSodium.Bindings.SHA2
   , cryptoAuthHMACSHA256Verify
   )
 import LibSodium.Bindings.SecureMemory (finalizerSodiumFree, sodiumMalloc)
-import Sel.Internal (allocateWith, foreignPtrEq, foreignPtrOrd)
+import Sel.Internal (allocateWith, foreignPtrEqConstantTime, foreignPtrOrd)
 
 -- $introduction
 -- The 'authenticate' function computes an authentication tag for a message and a secret key,
@@ -244,16 +244,14 @@ newtype AuthenticationKey = AuthenticationKey (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq AuthenticationKey where
   (AuthenticationKey hk1) == (AuthenticationKey hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq hk1 hk2 cryptoAuthHMACSHA256KeyBytes
+    foreignPtrEqConstantTime hk1 hk2 cryptoAuthHMACSHA256KeyBytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord AuthenticationKey where
   compare (AuthenticationKey hk1) (AuthenticationKey hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd hk1 hk2 cryptoAuthHMACSHA256KeyBytes
+    foreignPtrOrd hk1 hk2 cryptoAuthHMACSHA256KeyBytes
 
 -- | > show authenticationKey == "[REDACTED]"
 --
@@ -342,16 +340,14 @@ newtype AuthenticationTag = AuthenticationTag (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq AuthenticationTag where
   (AuthenticationTag hk1) == (AuthenticationTag hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq hk1 hk2 cryptoAuthHMACSHA256Bytes
+    foreignPtrEqConstantTime hk1 hk2 cryptoAuthHMACSHA256Bytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord AuthenticationTag where
   compare (AuthenticationTag hk1) (AuthenticationTag hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd hk1 hk2 cryptoAuthHMACSHA256Bytes
+    foreignPtrOrd hk1 hk2 cryptoAuthHMACSHA256Bytes
 
 -- |
 --

--- a/sel/src/Sel/HMAC/SHA512.hs
+++ b/sel/src/Sel/HMAC/SHA512.hs
@@ -81,7 +81,7 @@ import LibSodium.Bindings.SHA2
   , cryptoAuthHMACSHA512Verify
   )
 import LibSodium.Bindings.SecureMemory (finalizerSodiumFree, sodiumMalloc)
-import Sel.Internal (allocateWith, foreignPtrEq, foreignPtrOrd)
+import Sel.Internal (allocateWith, foreignPtrEqConstantTime, foreignPtrOrd)
 
 -- $introduction
 -- The 'authenticate' function computes an authentication tag for a message and a secret key,
@@ -244,16 +244,14 @@ newtype AuthenticationKey = AuthenticationKey (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq AuthenticationKey where
   (AuthenticationKey hk1) == (AuthenticationKey hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq hk1 hk2 cryptoAuthHMACSHA512KeyBytes
+    foreignPtrEqConstantTime hk1 hk2 cryptoAuthHMACSHA512KeyBytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord AuthenticationKey where
   compare (AuthenticationKey hk1) (AuthenticationKey hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd hk1 hk2 cryptoAuthHMACSHA512KeyBytes
+    foreignPtrOrd hk1 hk2 cryptoAuthHMACSHA512KeyBytes
 
 -- | > show authenticationKey == "[REDACTED]"
 --
@@ -342,16 +340,14 @@ newtype AuthenticationTag = AuthenticationTag (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq AuthenticationTag where
   (AuthenticationTag hk1) == (AuthenticationTag hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq hk1 hk2 cryptoAuthHMACSHA512Bytes
+    foreignPtrEqConstantTime hk1 hk2 cryptoAuthHMACSHA512Bytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord AuthenticationTag where
   compare (AuthenticationTag hk1) (AuthenticationTag hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd hk1 hk2 cryptoAuthHMACSHA512Bytes
+    foreignPtrOrd hk1 hk2 cryptoAuthHMACSHA512Bytes
 
 -- |
 --

--- a/sel/src/Sel/HMAC/SHA512_256.hs
+++ b/sel/src/Sel/HMAC/SHA512_256.hs
@@ -79,7 +79,7 @@ import LibSodium.Bindings.SHA2
   , cryptoAuthHMACSHA512256Verify
   )
 import LibSodium.Bindings.SecureMemory (finalizerSodiumFree, sodiumMalloc)
-import Sel.Internal (allocateWith, foreignPtrEq, foreignPtrOrd)
+import Sel.Internal (allocateWith, foreignPtrEq, foreignPtrEqConstantTime, foreignPtrOrd)
 
 -- $introduction
 -- The 'authenticate' function computes an authentication tag for a message and a secret key,
@@ -242,16 +242,14 @@ newtype AuthenticationKey = AuthenticationKey (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq AuthenticationKey where
   (AuthenticationKey hk1) == (AuthenticationKey hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq hk1 hk2 cryptoAuthHMACSHA512256KeyBytes
+    foreignPtrEqConstantTime hk1 hk2 cryptoAuthHMACSHA512256KeyBytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord AuthenticationKey where
   compare (AuthenticationKey hk1) (AuthenticationKey hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd hk1 hk2 cryptoAuthHMACSHA512256KeyBytes
+    foreignPtrOrd hk1 hk2 cryptoAuthHMACSHA512256KeyBytes
 
 -- | > show authenticationKey == "[REDACTED]"
 --
@@ -341,16 +339,14 @@ newtype AuthenticationTag = AuthenticationTag (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq AuthenticationTag where
   (AuthenticationTag hk1) == (AuthenticationTag hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq hk1 hk2 cryptoAuthHMACSHA512256Bytes
+    foreignPtrEq hk1 hk2 cryptoAuthHMACSHA512256Bytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord AuthenticationTag where
   compare (AuthenticationTag hk1) (AuthenticationTag hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd hk1 hk2 cryptoAuthHMACSHA512256Bytes
+    foreignPtrOrd hk1 hk2 cryptoAuthHMACSHA512256Bytes
 
 -- |
 --

--- a/sel/src/Sel/Hashing.hs
+++ b/sel/src/Sel/Hashing.hs
@@ -49,7 +49,6 @@ import qualified Foreign
 import Foreign.C (CChar, CInt, CSize, CUChar, CULLong)
 import Foreign.ForeignPtr
 import Foreign.Storable
-import System.IO.Unsafe (unsafeDupablePerformIO)
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Data.Base16.Types as Base16
@@ -94,13 +93,11 @@ newtype HashKey = HashKey (ForeignPtr CUChar)
 
 instance Eq HashKey where
   (HashKey hk1) == (HashKey hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq hk1 hk2 cryptoGenericHashKeyBytes
+    foreignPtrEq hk1 hk2 cryptoGenericHashKeyBytes
 
 instance Ord HashKey where
   compare (HashKey hk1) (HashKey hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd hk1 hk2 cryptoGenericHashKeyBytes
+    foreignPtrOrd hk1 hk2 cryptoGenericHashKeyBytes
 
 -- | Create a new 'HashKey' of size 'cryptoGenericHashKeyBytes'.
 --
@@ -127,16 +124,14 @@ newtype Hash = Hash (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq Hash where
   (Hash h1) == (Hash h2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq h1 h2 cryptoGenericHashBytes
+    foreignPtrEq h1 h2 cryptoGenericHashBytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord Hash where
   compare (Hash h1) (Hash h2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd h1 h2 cryptoGenericHashBytes
+    foreignPtrOrd h1 h2 cryptoGenericHashBytes
 
 -- |
 --

--- a/sel/src/Sel/Hashing/Password.hs
+++ b/sel/src/Sel/Hashing/Password.hs
@@ -94,20 +94,18 @@ instance Display PasswordHash where
 -- | @since 0.0.1.0
 instance Eq PasswordHash where
   (PasswordHash ph1) == (PasswordHash ph2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq
-        (Foreign.castForeignPtr @CChar @CUChar ph1)
-        (Foreign.castForeignPtr @CChar @CUChar ph2)
-        cryptoPWHashStrBytes
+    foreignPtrEq
+      (Foreign.castForeignPtr @CChar @CUChar ph1)
+      (Foreign.castForeignPtr @CChar @CUChar ph2)
+      cryptoPWHashStrBytes
 
 -- | @since 0.0.1.0
 instance Ord PasswordHash where
   (PasswordHash ph1) `compare` (PasswordHash ph2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd
-        (Foreign.castForeignPtr @CChar @CUChar ph1)
-        (Foreign.castForeignPtr @CChar @CUChar ph2)
-        cryptoPWHashStrBytes
+    foreignPtrOrd
+      (Foreign.castForeignPtr @CChar @CUChar ph1)
+      (Foreign.castForeignPtr @CChar @CUChar ph2)
+      cryptoPWHashStrBytes
 
 -- | @since 0.0.1.0
 instance Show PasswordHash where

--- a/sel/src/Sel/Hashing/Password.hs
+++ b/sel/src/Sel/Hashing/Password.hs
@@ -95,13 +95,19 @@ instance Display PasswordHash where
 instance Eq PasswordHash where
   (PasswordHash ph1) == (PasswordHash ph2) =
     unsafeDupablePerformIO $
-      foreignPtrEq ph1 ph2 cryptoPWHashStrBytes
+      foreignPtrEq
+        (Foreign.castForeignPtr @CChar @CUChar ph1)
+        (Foreign.castForeignPtr @CChar @CUChar ph2)
+        cryptoPWHashStrBytes
 
 -- | @since 0.0.1.0
 instance Ord PasswordHash where
   (PasswordHash ph1) `compare` (PasswordHash ph2) =
     unsafeDupablePerformIO $
-      foreignPtrOrd ph1 ph2 cryptoPWHashStrBytes
+      foreignPtrOrd
+        (Foreign.castForeignPtr @CChar @CUChar ph1)
+        (Foreign.castForeignPtr @CChar @CUChar ph2)
+        cryptoPWHashStrBytes
 
 -- | @since 0.0.1.0
 instance Show PasswordHash where

--- a/sel/src/Sel/Hashing/SHA256.hs
+++ b/sel/src/Sel/Hashing/SHA256.hs
@@ -53,7 +53,6 @@ import LibSodium.Bindings.SHA2
   , cryptoHashSHA256StateBytes
   , cryptoHashSHA256Update
   )
-import System.IO.Unsafe (unsafeDupablePerformIO)
 
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import qualified Data.Base16.Types as Base16
@@ -83,16 +82,14 @@ newtype Hash = Hash (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq Hash where
   (Hash h1) == (Hash h2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq h1 h2 cryptoHashSHA256Bytes
+    foreignPtrEq h1 h2 cryptoHashSHA256Bytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord Hash where
   compare (Hash h1) (Hash h2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd h1 h2 cryptoHashSHA256Bytes
+    foreignPtrOrd h1 h2 cryptoHashSHA256Bytes
 
 -- |
 --

--- a/sel/src/Sel/Hashing/SHA512.hs
+++ b/sel/src/Sel/Hashing/SHA512.hs
@@ -53,7 +53,6 @@ import LibSodium.Bindings.SHA2
   , cryptoHashSHA512StateBytes
   , cryptoHashSHA512Update
   )
-import System.IO.Unsafe (unsafeDupablePerformIO)
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Data.Base16.Types as Base16
@@ -83,16 +82,14 @@ newtype Hash = Hash (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq Hash where
   (Hash h1) == (Hash h2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq h1 h2 cryptoHashSHA512Bytes
+    foreignPtrEq h1 h2 cryptoHashSHA512Bytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord Hash where
   compare (Hash h1) (Hash h2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd h1 h2 cryptoHashSHA512Bytes
+    foreignPtrOrd h1 h2 cryptoHashSHA512Bytes
 
 -- |
 --

--- a/sel/src/Sel/Hashing/Short.hs
+++ b/sel/src/Sel/Hashing/Short.hs
@@ -89,16 +89,14 @@ newtype ShortHash = ShortHash (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq ShortHash where
   (ShortHash sh1) == (ShortHash sh2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq sh1 sh2 cryptoShortHashSipHashX24Bytes
+    foreignPtrEq sh1 sh2 cryptoShortHashSipHashX24Bytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord ShortHash where
   compare (ShortHash sh1) (ShortHash sh2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd sh1 sh2 cryptoShortHashSipHashX24Bytes
+    foreignPtrOrd sh1 sh2 cryptoShortHashSipHashX24Bytes
 
 -- |
 --
@@ -188,16 +186,14 @@ newtype ShortHashKey = ShortHashKey (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq ShortHashKey where
   (ShortHashKey sh1) == (ShortHashKey sh2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq sh1 sh2 cryptoShortHashSipHashX24Bytes
+    foreignPtrEq sh1 sh2 cryptoShortHashSipHashX24Bytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord ShortHashKey where
   compare (ShortHashKey sh1) (ShortHashKey sh2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd sh1 sh2 cryptoShortHashSipHashX24Bytes
+    foreignPtrOrd sh1 sh2 cryptoShortHashSipHashX24Bytes
 
 -- |
 --

--- a/sel/src/Sel/Internal.hs
+++ b/sel/src/Sel/Internal.hs
@@ -1,53 +1,104 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Sel.Internal where
 
+import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import qualified Data.Base16.Types as Base16
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.ByteString.Internal as BS
+import Control.Monad.Trans.Class (lift)
+import Data.Base16.Types qualified as Base16
+import Data.ByteString (StrictByteString)
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Internal (memcmp)
+import Data.ByteString.Internal qualified as ByteString
+import Data.Coerce (coerce)
 import Data.Kind (Type)
-import Foreign (Ptr, castForeignPtr)
-import Foreign.C.Types (CInt (CInt), CSize (CSize))
-import Foreign.ForeignPtr (ForeignPtr, withForeignPtr)
-import LibSodium.Bindings.SecureMemory (sodiumFree, sodiumMalloc)
+import Foreign (ForeignPtr, Ptr)
+import Foreign qualified
+import Foreign.C (CSize, CUChar, throwErrno)
+import Foreign.C.Types (CChar)
+import LibSodium.Bindings.Comparison (sodiumMemcmp)
+import LibSodium.Bindings.SecureMemory (finalizerSodiumFree, sodiumFree, sodiumMalloc)
+import Sel.Internal.Scoped
+import Sel.Internal.Scoped.Foreign
+import System.IO.Unsafe (unsafeDupablePerformIO)
 
--- | This calls to C's @memcmp@ function, used in lieu of
--- libsodium's @memcmp@ in cases when the return code is necessary.
-foreign import capi unsafe "string.h memcmp"
-  memcmp :: Ptr a -> Ptr b -> CSize -> IO CInt
+-- | Compare the contents of two byte arrays in constant time.
+--
+-- /See:/ [Constant-time test for equality](https://doc.libsodium.org/helpers#constant-time-test-for-equality)
+--
+-- @since 0.0.3.0
+foreignPtrEqConstantTime :: ForeignPtr CUChar -> ForeignPtr CUChar -> CSize -> Bool
+foreignPtrEqConstantTime p q size =
+  unsafeDupablePerformIO . fmap (== 0) . use $
+    sodiumMemcmp <$> foreignPtr p <*> foreignPtr q <*> pure size
 
--- | Compare if the contents of two @ForeignPtr@s are equal.
-foreignPtrEq :: ForeignPtr a -> ForeignPtr a -> CSize -> IO Bool
-foreignPtrEq fptr1 fptr2 size =
-  withForeignPtr fptr1 $ \p ->
-    withForeignPtr fptr2 $ \q ->
-      do
-        result <- memcmp p q size
-        return $ 0 == result
+-- | Lexicographically compare the contents of two byte arrays.
+--
+-- ⚠️ Such comparisons are vulnerable to timing attacks, and should be
+-- avoided for secret data.
+--
+-- @since 0.0.1.0
+foreignPtrOrd :: ForeignPtr CUChar -> ForeignPtr CUChar -> CSize -> Ordering
+foreignPtrOrd p q size =
+  unsafeDupablePerformIO . fmap (`compare` 0) . useM $
+    memcmp
+      <$> foreignPtr (coerce p)
+      <*> foreignPtr (coerce q)
+      <*> pure (fromIntegral size)
 
--- | Compare the contents of two @ForeignPtr@s using lexicographical ordering.
-foreignPtrOrd :: ForeignPtr a -> ForeignPtr a -> CSize -> IO Ordering
-foreignPtrOrd fptr1 fptr2 size =
-  withForeignPtr fptr1 $ \p ->
-    withForeignPtr fptr2 $ \q ->
-      do
-        result <- memcmp p q size
-        return $
-          if
-            | result == 0 -> EQ
-            | result < 0 -> LT
-            | otherwise -> GT
+-- | Compare two byte arrays for lexicographic equality.
+--
+-- ⚠️ Such comparisons are vulnerable to timing attacks, and should be
+-- avoided for secret data.
+--
+-- @since 0.0.1.0
+foreignPtrEq :: ForeignPtr CUChar -> ForeignPtr CUChar -> CSize -> Bool
+foreignPtrEq p q size = foreignPtrOrd p q size == EQ
 
+-- | Convert a @'ForeignPtr' a@ to a 'ByteString' of the given length
+-- and render the hexadecimal-encoded bytes as a 'String'.
+--
+-- @since 0.0.1.0
 foreignPtrShow :: ForeignPtr a -> CSize -> String
-foreignPtrShow fptr size =
-  BS.unpackChars . Base16.extractBase16 . Base16.encodeBase16' $
-    BS.fromForeignPtr (Foreign.castForeignPtr fptr) 0 (fromIntegral @CSize @Int size)
+foreignPtrShow (Foreign.castForeignPtr -> cstring) size =
+  ByteString.unpackChars . Base16.extractBase16 . Base16.encodeBase16' $
+    ByteString.fromForeignPtr cstring 0 (fromIntegral @CSize @Int size)
+
+-- | Copy a byte array to a @libsodium@ pointer.
+--
+-- The size of the array is not checked. The input may be truncated if
+-- it is too long, or an unchecked exception may be thrown if it is
+-- too short.
+--
+-- @since 0.0.3.0
+unsafeCopyToSodiumPointer :: CSize -> StrictByteString -> IO (ForeignPtr CUChar)
+unsafeCopyToSodiumPointer size s = use $ do
+  str <- unsafeCString s
+  lift $ sodiumPointer size $ \k ->
+    Foreign.copyArray
+      (Foreign.castPtr @CUChar @CChar k)
+      str
+      (fromIntegral @CSize @Int size)
+
+-- | Allocate secure memory and populate it with the provided action.
+--
+-- Memory is allocated with 'LibSodium.Bindings.SecureMemory.sodiumMalloc' (see notes).
+--
+-- A finalizer frees the memory when the key goes out of scope.
+--
+-- @since 0.0.3.0
+sodiumPointer :: CSize -> (Ptr CUChar -> IO ()) -> IO (ForeignPtr CUChar)
+sodiumPointer size action = do
+  ptr <- sodiumMalloc size
+  when (ptr == Foreign.nullPtr) $ do
+    throwErrno "sodium_malloc"
+  action ptr
+  Foreign.newForeignPtr finalizerSodiumFree ptr
 
 -- | Securely allocate an amount of memory with 'sodiumMalloc' and pass
 -- a pointer to the region to the provided action.

--- a/sel/src/Sel/PublicKey/Signature.hs
+++ b/sel/src/Sel/PublicKey/Signature.hs
@@ -81,16 +81,14 @@ newtype PublicKey = PublicKey (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq PublicKey where
   (PublicKey pk1) == (PublicKey pk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq pk1 pk2 cryptoSignPublicKeyBytes
+    foreignPtrEq pk1 pk2 cryptoSignPublicKeyBytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord PublicKey where
   compare (PublicKey pk1) (PublicKey pk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd pk1 pk2 cryptoSignPublicKeyBytes
+    foreignPtrOrd pk1 pk2 cryptoSignPublicKeyBytes
 
 -- |
 --
@@ -102,16 +100,14 @@ newtype SecretKey = SecretKey (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq SecretKey where
   (SecretKey sk1) == (SecretKey sk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq sk1 sk2 cryptoSignSecretKeyBytes
+    foreignPtrEqConstantTime sk1 sk2 cryptoSignSecretKeyBytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord SecretKey where
   compare (SecretKey sk1) (SecretKey sk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd sk1 sk2 cryptoSignSecretKeyBytes
+    foreignPtrOrd sk1 sk2 cryptoSignSecretKeyBytes
 
 -- |
 --
@@ -127,20 +123,24 @@ data SignedMessage = SignedMessage
 -- @since 0.0.1.0
 instance Eq SignedMessage where
   (SignedMessage len1 msg1 sig1) == (SignedMessage len2 msg2 sig2) =
-    unsafeDupablePerformIO $ do
-      result1 <- foreignPtrEq msg1 msg2 len1
-      result2 <- foreignPtrEq sig1 sig2 cryptoSignBytes
-      return $ (len1 == len2) && result1 && result2
+    let
+      messageLength = len1 == len2
+      msg1Eq = foreignPtrEq msg1 msg2 len1
+      msg2Eq = foreignPtrEq sig1 sig2 cryptoSignBytes
+     in
+      messageLength && msg1Eq && msg2Eq
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord SignedMessage where
   compare (SignedMessage len1 msg1 sig1) (SignedMessage len2 msg2 sig2) =
-    unsafeDupablePerformIO $ do
-      result1 <- foreignPtrOrd msg1 msg2 len1
-      result2 <- foreignPtrOrd sig1 sig2 cryptoSignBytes
-      return $ compare len1 len2 <> result1 <> result2
+    let
+      messageLength = compare len1 len2
+      msg1Ord = foreignPtrOrd msg1 msg2 len1
+      msg2Ord = foreignPtrOrd sig1 sig2 cryptoSignBytes
+     in
+      messageLength <> msg1Ord <> msg2Ord
 
 -- | Generate a pair of public and secret key.
 --

--- a/sel/src/Sel/Scrypt.hs
+++ b/sel/src/Sel/Scrypt.hs
@@ -38,7 +38,6 @@ import Foreign hiding (void)
 import Foreign.C
 import LibSodium.Bindings.Scrypt
 import Sel.Internal
-import System.IO.Unsafe (unsafeDupablePerformIO)
 
 -- $introduction
 --
@@ -54,20 +53,18 @@ newtype ScryptHash = ScryptHash (ForeignPtr CChar)
 -- | @since 0.0.1.0
 instance Eq ScryptHash where
   (ScryptHash sh1) == (ScryptHash sh2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq
-        (Foreign.castForeignPtr @CChar @CUChar sh1)
-        (Foreign.castForeignPtr @CChar @CUChar sh2)
-        cryptoPWHashScryptSalsa208SHA256StrBytes
+    foreignPtrEq
+      (Foreign.castForeignPtr @CChar @CUChar sh1)
+      (Foreign.castForeignPtr @CChar @CUChar sh2)
+      cryptoPWHashScryptSalsa208SHA256StrBytes
 
 -- | @since 0.0.1.0
 instance Ord ScryptHash where
   compare (ScryptHash sh1) (ScryptHash sh2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd
-        (Foreign.castForeignPtr @CChar @CUChar sh1)
-        (Foreign.castForeignPtr @CChar @CUChar sh2)
-        cryptoPWHashScryptSalsa208SHA256StrBytes
+    foreignPtrOrd
+      (Foreign.castForeignPtr @CChar @CUChar sh1)
+      (Foreign.castForeignPtr @CChar @CUChar sh2)
+      cryptoPWHashScryptSalsa208SHA256StrBytes
 
 -- | @since 0.0.1.0
 instance Show ScryptHash where

--- a/sel/src/Sel/Scrypt.hs
+++ b/sel/src/Sel/Scrypt.hs
@@ -55,13 +55,19 @@ newtype ScryptHash = ScryptHash (ForeignPtr CChar)
 instance Eq ScryptHash where
   (ScryptHash sh1) == (ScryptHash sh2) =
     unsafeDupablePerformIO $
-      foreignPtrEq sh1 sh2 cryptoPWHashScryptSalsa208SHA256StrBytes
+      foreignPtrEq
+        (Foreign.castForeignPtr @CChar @CUChar sh1)
+        (Foreign.castForeignPtr @CChar @CUChar sh2)
+        cryptoPWHashScryptSalsa208SHA256StrBytes
 
 -- | @since 0.0.1.0
 instance Ord ScryptHash where
   compare (ScryptHash sh1) (ScryptHash sh2) =
     unsafeDupablePerformIO $
-      foreignPtrOrd sh1 sh2 cryptoPWHashScryptSalsa208SHA256StrBytes
+      foreignPtrOrd
+        (Foreign.castForeignPtr @CChar @CUChar sh1)
+        (Foreign.castForeignPtr @CChar @CUChar sh2)
+        cryptoPWHashScryptSalsa208SHA256StrBytes
 
 -- | @since 0.0.1.0
 instance Show ScryptHash where

--- a/sel/src/Sel/SecretKey/Authentication.hs
+++ b/sel/src/Sel/SecretKey/Authentication.hs
@@ -145,16 +145,14 @@ newtype AuthenticationKey = AuthenticationKey (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq AuthenticationKey where
   (AuthenticationKey hk1) == (AuthenticationKey hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq hk1 hk2 cryptoAuthKeyBytes
+    foreignPtrEqConstantTime hk1 hk2 cryptoAuthKeyBytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord AuthenticationKey where
   compare (AuthenticationKey hk1) (AuthenticationKey hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd hk1 hk2 cryptoAuthKeyBytes
+    foreignPtrOrd hk1 hk2 cryptoAuthKeyBytes
 
 -- | > show authenticationKey == "[REDACTED]"
 --
@@ -233,16 +231,14 @@ newtype AuthenticationTag = AuthenticationTag (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq AuthenticationTag where
   (AuthenticationTag hk1) == (AuthenticationTag hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq hk1 hk2 cryptoAuthBytes
+    foreignPtrEqConstantTime hk1 hk2 cryptoAuthBytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord AuthenticationTag where
   compare (AuthenticationTag hk1) (AuthenticationTag hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd hk1 hk2 cryptoAuthBytes
+    foreignPtrOrd hk1 hk2 cryptoAuthBytes
 
 -- |
 --

--- a/sel/src/Sel/SecretKey/Cipher.hs
+++ b/sel/src/Sel/SecretKey/Cipher.hs
@@ -110,16 +110,14 @@ newtype SecretKey = SecretKey (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq SecretKey where
   (SecretKey hk1) == (SecretKey hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq hk1 hk2 cryptoSecretboxKeyBytes
+    foreignPtrEqConstantTime hk1 hk2 cryptoSecretboxKeyBytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord SecretKey where
   compare (SecretKey hk1) (SecretKey hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd hk1 hk2 cryptoSecretboxKeyBytes
+    foreignPtrOrd hk1 hk2 cryptoSecretboxKeyBytes
 
 -- | > show secretKey == "[REDACTED]"
 --
@@ -200,16 +198,14 @@ newtype Nonce = Nonce (ForeignPtr CUChar)
 -- @since 0.0.1.0
 instance Eq Nonce where
   (Nonce hk1) == (Nonce hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq hk1 hk2 cryptoSecretboxNonceBytes
+    foreignPtrEq hk1 hk2 cryptoSecretboxNonceBytes
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord Nonce where
   compare (Nonce hk1) (Nonce hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd hk1 hk2 cryptoSecretboxNonceBytes
+    foreignPtrOrd hk1 hk2 cryptoSecretboxNonceBytes
 
 -- |
 --
@@ -275,22 +271,30 @@ data Hash = Hash
 -- @since 0.0.1.0
 instance Eq Hash where
   (Hash messageLength1 hk1) == (Hash messageLength2 hk2) =
-    unsafeDupablePerformIO $ do
-      result1 <-
-        foreignPtrEq
+    let
+      messageLength = messageLength1 == messageLength2
+      content =
+        foreignPtrEqConstantTime
           hk1
           hk2
           (fromIntegral messageLength1 + cryptoSecretboxMACBytes)
-      pure $ (messageLength1 == messageLength2) && result1
+     in
+      messageLength && content
 
 -- |
 --
 -- @since 0.0.1.0
 instance Ord Hash where
   compare (Hash messageLength1 hk1) (Hash messageLength2 hk2) =
-    unsafeDupablePerformIO $ do
-      result1 <- foreignPtrOrd hk1 hk2 (fromIntegral messageLength1 + cryptoSecretboxMACBytes)
-      pure $ compare messageLength1 messageLength2 <> result1
+    let
+      messageLength = compare messageLength1 messageLength2
+      content =
+        foreignPtrOrd
+          hk1
+          hk2
+          (fromIntegral messageLength1 + cryptoSecretboxMACBytes)
+     in
+      messageLength <> content
 
 -- | ⚠️  Be prudent as to what you do with it!
 --

--- a/sel/src/Sel/SecretKey/Stream.hs
+++ b/sel/src/Sel/SecretKey/Stream.hs
@@ -314,14 +314,12 @@ newtype SecretKey = SecretKey (ForeignPtr CUChar)
 -- | @since 0.0.1.0
 instance Eq SecretKey where
   (SecretKey hk1) == (SecretKey hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq hk1 hk2 cryptoSecretStreamXChaCha20Poly1305KeyBytes
+    foreignPtrEq hk1 hk2 cryptoSecretStreamXChaCha20Poly1305KeyBytes
 
 -- | @since 0.0.1.0
 instance Ord SecretKey where
   compare (SecretKey hk1) (SecretKey hk2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd hk1 hk2 cryptoSecretStreamXChaCha20Poly1305KeyBytes
+    foreignPtrOrd hk1 hk2 cryptoSecretStreamXChaCha20Poly1305KeyBytes
 
 -- | > show secretKey == "[REDACTED]"
 --
@@ -403,14 +401,12 @@ instance Display Header where
 -- | @since 0.0.1.0
 instance Eq Header where
   (Header header1) == (Header header2) =
-    unsafeDupablePerformIO $
-      foreignPtrEq header1 header2 cryptoSecretStreamXChaCha20Poly1305HeaderBytes
+    foreignPtrEq header1 header2 cryptoSecretStreamXChaCha20Poly1305HeaderBytes
 
 -- | @since 0.0.1.0
 instance Ord Header where
   compare (Header header1) (Header header2) =
-    unsafeDupablePerformIO $
-      foreignPtrOrd header1 header2 cryptoSecretStreamXChaCha20Poly1305HeaderBytes
+    foreignPtrOrd header1 header2 cryptoSecretStreamXChaCha20Poly1305HeaderBytes
 
 -- | Convert a 'Header' to a hexadecimal-encoded 'StrictByteString'
 --
@@ -485,20 +481,28 @@ data CipherText = CipherText
 -- @since 0.0.1.0
 instance Eq CipherText where
   (CipherText cipherTextLength1 h1) == (CipherText cipherTextLength2 h2) =
-    unsafeDupablePerformIO $ do
-      result1 <-
+    let
+      textLength = cipherTextLength1 == cipherTextLength2
+      content =
         foreignPtrEq
           h1
           h2
           (fromIntegral cipherTextLength1 + cryptoSecretStreamXChaCha20Poly1305ABytes)
-      pure $ cipherTextLength1 == cipherTextLength2 && result1
+     in
+      textLength && content
 
 -- | @since 0.0.1.0
 instance Ord CipherText where
   compare (CipherText cipherTextLength1 c1) (CipherText cipherTextLength2 c2) =
-    unsafeDupablePerformIO $ do
-      result1 <- foreignPtrOrd c1 c2 (fromIntegral cipherTextLength1 + cryptoSecretStreamXChaCha20Poly1305ABytes)
-      pure $ compare cipherTextLength1 cipherTextLength2 <> result1
+    let
+      textLength = compare cipherTextLength1 cipherTextLength2
+      content =
+        foreignPtrOrd
+          c1
+          c2
+          (fromIntegral cipherTextLength1 + cryptoSecretStreamXChaCha20Poly1305ABytes)
+     in
+      textLength <> content
 
 -- | @since 0.0.1.0
 instance Display CipherText where


### PR DESCRIPTION
Constant-time comparison helps avoid timing attacks on secret cryptographic material.

Also adds functions for interacting with `sodium_malloc`'d pointers.

Stack
- #169 <- you are here
- https://github.com/jhenahan/libsodium-bindings/pull/2
- https://github.com/jhenahan/libsodium-bindings/pull/3