### PR TITLE
feat(Signature): add serde functions, hide internals

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
         id: setup-haskell
         uses: haskell-actions/setup@v2
         with:
-          ghc-version: '9.8.2'
+          ghc-version: '9.10.1'
           cabal-version: 'latest'
 
       - name: Freeze

--- a/sel/sel.cabal
+++ b/sel/sel.cabal
@@ -54,6 +54,7 @@ library
     Sel.HMAC.SHA256
     Sel.HMAC.SHA512
     Sel.HMAC.SHA512_256
+    Sel.KeyMaterialDecodeError
     Sel.PublicKey.Cipher
     Sel.PublicKey.Seal
     Sel.PublicKey.Signature
@@ -66,6 +67,7 @@ library
     Sel.Internal
     Sel.Internal.Scoped
     Sel.Internal.Scoped.Foreign
+    Sel.PublicKey.Internal.Signature
 
   build-depends:
     , base                >=4.14   && <5

--- a/sel/src/Sel/KeyMaterialDecodeError.hs
+++ b/sel/src/Sel/KeyMaterialDecodeError.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- |
+-- Module      : Sel.KeyMaterialDecodeError
+-- Description : Key material utilities
+-- Copyright   : (c) Jack Henahan, 2024
+-- License     : BSD-3-Clause
+-- Maintainer  : The Haskell Cryptography Group
+-- Portability : GHC only
+module Sel.KeyMaterialDecodeError
+  ( -- * Key material utilities
+    KeyMaterialDecodeError (..)
+  , RequiredLength (..)
+  , InputLength (..)
+  , validKeyMaterial
+  )
+where
+
+import Control.Exception (Exception)
+import Data.Bifunctor (first)
+import Data.ByteString (StrictByteString)
+import Data.ByteString qualified as ByteString
+import Data.ByteString.Base16 qualified as Base16
+import Data.Coerce (coerce)
+import Data.Text (Text)
+import Data.Text.Display (Display, ShowInstance (..))
+import Foreign.C (CSize (..))
+
+-- | Errors arising from decoding key material from bytes.
+--
+-- @since 0.0.3.0
+data KeyMaterialDecodeError
+  = -- | Input length does not match the length required for the target pointer.
+    --
+    -- @since 0.0.3.0
+    ByteLengthMismatch RequiredLength InputLength
+  | -- | Input bytes did not decode to hexadecimal.
+    --
+    -- @since 0.0.3.0
+    DecodingFailure Text
+  deriving stock
+    ( Show
+      -- ^ @since 0.0.3.0
+    , Eq
+      -- ^ @since 0.0.3.0
+    )
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+    )
+    via (ShowInstance KeyMaterialDecodeError)
+  deriving anyclass
+    ( Exception
+      -- ^ @since 0.0.3.0
+    )
+
+-- | The length of the target pointer for some key material.
+--
+-- @since 0.0.3.0
+newtype RequiredLength = RequiredLength Int
+  deriving stock
+    ( Show
+      -- ^ @since 0.0.3.0
+    , Eq
+      -- ^ @since 0.0.3.0
+    )
+
+-- | The length of some input bytes.
+--
+-- @since 0.0.3.0
+newtype InputLength = InputLength Int
+  deriving stock
+    ( Show
+      -- ^ @since 0.0.3.0
+    , Eq
+      -- ^ @since 0.0.3.0
+    )
+
+-- | Attempt to decode a hexadecimal-encoded 'StrictByteString' with an expected length.
+--
+-- @since 0.0.3.0
+validKeyMaterial :: CSize -> StrictByteString -> Either KeyMaterialDecodeError StrictByteString
+validKeyMaterial (fromIntegral -> requiredLength) bytes = do
+  decoded@(ByteString.length -> inputLength) <-
+    first DecodingFailure (Base16.decodeBase16Untyped bytes)
+  if requiredLength == inputLength
+    then Right decoded
+    else Left $ ByteLengthMismatch (coerce requiredLength) (coerce inputLength)

--- a/sel/src/Sel/PublicKey/Internal/Signature.hs
+++ b/sel/src/Sel/PublicKey/Internal/Signature.hs
@@ -1,0 +1,457 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Sel.PublicKey.Internal.Signature
+  ( -- ** Public Keys
+    PublicKey
+  , decodePublicKeyHexByteString
+  , encodePublicKeyHexByteString
+
+    -- ** Secret Keys
+  , SecretKey
+  , decodeSecretKeyHexByteString
+  , unsafeEncodeSecretKeyHexByteString
+  , publicKey
+
+    -- ** Key Pairs
+  , KeyPair (..)
+  , keyPair
+
+    -- ** Signed Messages
+  , SignedMessage
+  , sign
+  , open
+  , SignatureVerification (..)
+  , extractUnverifiedMessage
+  , extractSignature
+  , buildSignedMessage
+
+    -- ** Exceptions
+  , PublicKeyExtractionException (..)
+  )
+where
+
+import Control.Exception (Exception, throw)
+import Control.Monad (unless)
+import Control.Monad.Trans.Class (lift)
+import Data.Base16.Types qualified as Base16
+import Data.ByteString (StrictByteString)
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Internal qualified as ByteString
+import Data.ByteString.Unsafe qualified as ByteString
+import Data.Coerce (coerce)
+import Data.Text.Display (Display, OpaqueInstance (..), ShowInstance (..))
+import Data.Traversable (for)
+import Foreign (ForeignPtr)
+import Foreign qualified
+import Foreign.C (CChar, CSize, CUChar, CULLong)
+import LibSodium.Bindings.CryptoSign
+  ( cryptoSignBytes
+  , cryptoSignDetached
+  , cryptoSignED25519SkToPk
+  , cryptoSignKeyPair
+  , cryptoSignPublicKeyBytes
+  , cryptoSignSecretKeyBytes
+  , cryptoSignVerifyDetached
+  )
+import Sel.Internal
+  ( foreignPtrEq
+  , foreignPtrEqConstantTime
+  , foreignPtrOrd
+  , foreignPtrOrdConstantTime
+  , unsafeCopyToSodiumPointer
+  )
+import Sel.Internal.Scoped
+import Sel.Internal.Scoped.Foreign
+  ( copyArray
+  , foreignPtr
+  , mallocBytes
+  , mallocForeignPtrBytes
+  , unsafeCString
+  , unsafeCStringLen
+  )
+import Sel.KeyMaterialDecodeError
+import System.IO.Unsafe (unsafeDupablePerformIO)
+
+-- | A public key of size 'cryptoSignPublicKeyBytes', suitable for
+-- publication to third parties for message verification.
+--
+-- @since 0.0.1.0
+newtype PublicKey = PublicKey (ForeignPtr CUChar)
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+      -- Hexadecimal-encoded bytes.
+    )
+    via (ShowInstance PublicKey)
+
+-- | By lexicographical comparison of pointer contents.
+--
+-- @since 0.0.1.0
+instance Eq PublicKey where
+  a == b =
+    foreignPtrEq (coerce a) (coerce b) cryptoSignPublicKeyBytes
+
+-- | By lexicographical comparison of pointer contents.
+--
+-- @since 0.0.1.0
+instance Ord PublicKey where
+  a `compare` b =
+    foreignPtrOrd (coerce a) (coerce b) cryptoSignPublicKeyBytes
+
+-- | Hexadecimal-encoded bytes.
+--
+-- @since 0.0.3.0
+instance Show PublicKey where
+  show = ByteString.unpackChars . encodePublicKeyHexByteString
+
+-- | Decode a hexadecimal-encoded 'StrictByteString' to a t'PublicKey'.
+--
+-- @since 0.0.3.0
+decodePublicKeyHexByteString :: StrictByteString -> Either KeyMaterialDecodeError PublicKey
+decodePublicKeyHexByteString bytes = PublicKey <$> copyHexKey cryptoSignPublicKeyBytes bytes
+
+-- | Encode a t'PublicKey' to a hexadecimal encoded 'StrictByteString'.
+--
+-- @since 0.0.3.0
+encodePublicKeyHexByteString :: PublicKey -> StrictByteString
+encodePublicKeyHexByteString (PublicKey publicKeyPtr) =
+  Base16.extractBase16 . Base16.encodeBase16' $
+    ByteString.fromForeignPtr0
+      (Foreign.castForeignPtr publicKeyPtr)
+      (fromIntegral cryptoSignPublicKeyBytes)
+
+-- | A secret key of size 'cryptoSignSecretKeyBytes'. Keep this private.
+--
+-- @since 0.0.1.0
+newtype SecretKey = SecretKey (ForeignPtr CUChar)
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+      -- > display secretKey == "[REDACTED]"
+    )
+    via (OpaqueInstance "[REDACTED]" SecretKey)
+
+-- | By constant-time comparison of pointer contents.
+--
+-- @since 0.0.3.0
+instance Eq SecretKey where
+  a == b =
+    foreignPtrEqConstantTime (coerce a) (coerce b) cryptoSignSecretKeyBytes
+
+-- | By constant-time lexicographical comparison of pointer contents.
+--
+-- @since 0.0.3.0
+instance Ord SecretKey where
+  a `compare` b =
+    foreignPtrOrdConstantTime (coerce a) (coerce b) cryptoSignSecretKeyBytes
+
+-- | > show secretKey == "[REDACTED]"
+--
+-- @since 0.0.3.0
+instance Show SecretKey where
+  show _ = "[REDACTED]"
+
+-- | Decode a hexadecimal-encoded 'StrictByteString' to a t'SecretKey'.
+--
+-- @since 0.0.3.0
+decodeSecretKeyHexByteString :: StrictByteString -> Either KeyMaterialDecodeError SecretKey
+decodeSecretKeyHexByteString bytes = SecretKey <$> copyHexKey cryptoSignSecretKeyBytes bytes
+
+-- | Encode a t'SecretKey' to a hexadecimal encoded 'StrictByteString'.
+--
+-- ⚠️ This is a security risk! Be careful how you use the output of
+-- this function!
+--
+-- @since 0.0.3.0
+unsafeEncodeSecretKeyHexByteString :: SecretKey -> StrictByteString
+unsafeEncodeSecretKeyHexByteString (SecretKey secretKeyPtr) =
+  Base16.extractBase16 . Base16.encodeBase16' $
+    ByteString.fromForeignPtr0
+      (Foreign.castForeignPtr secretKeyPtr)
+      (fromIntegral cryptoSignSecretKeyBytes)
+
+-- | Produce the t'PublicKey' from a t'SecretKey'.
+--
+-- This function may throw a t'PublicKeyExtractionException' if the
+-- operation fails.
+publicKey :: SecretKey -> PublicKey
+publicKey (SecretKey secretKeyPtr) = unsafeDupablePerformIO $ do
+  publicKeyPtr <- Foreign.mallocForeignPtrBytes (fromIntegral cryptoSignPublicKeyBytes)
+  res <-
+    useM $
+      cryptoSignED25519SkToPk
+        <$> foreignPtr publicKeyPtr
+        <*> foreignPtr secretKeyPtr
+  unless (res == 0) $ throw PublicKeyExtractionException
+  pure $ PublicKey publicKeyPtr
+
+-- | A signing key pair, comprising a t'PublicKey' and a t'SecretKey'.
+--
+-- @since 0.0.3.0
+data KeyPair = KeyPair {public :: PublicKey, secret :: SecretKey}
+  deriving stock
+    ( Show
+      -- ^ @since 0.0.3.0
+      -- Follows the instances for t'PublicKey' and t'SecretKey', respectively.
+      --
+      -- In particular, the secret key will be shown as @[REDACTED]@.
+    , Eq
+      -- ^ @since 0.0.3.0
+      -- Follows the instances for t'PublicKey' and t'SecretKey', respectively.
+    )
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+      -- Follows the instances for t'PublicKey' and t'SecretKey', respectively.
+      --
+      -- In particular, the secret key will be displayed as @[REDACTED]@.
+    )
+    via (ShowInstance KeyPair)
+
+-- | By lexicographical comparison of key pointer contents.
+--
+-- @since 0.0.3.0
+instance Ord KeyPair where
+  compare kp1 kp2 =
+    compare kp1.public kp2.public
+      <> compare kp1.secret kp2.secret
+
+-- | Generate a fresh t'KeyPair'.
+--
+-- @since 0.0.3.0
+keyPair :: IO KeyPair
+keyPair = do
+  publicKeyPtr <- Foreign.mallocForeignPtrBytes (fromIntegral cryptoSignPublicKeyBytes)
+  secretKeyPtr <- Foreign.mallocForeignPtrBytes (fromIntegral cryptoSignSecretKeyBytes)
+  useM_ $ cryptoSignKeyPair <$> foreignPtr publicKeyPtr <*> foreignPtr secretKeyPtr
+  pure $ KeyPair (PublicKey publicKeyPtr) (SecretKey secretKeyPtr)
+
+-- | A message of known length together with its signature of length
+-- 'cryptoSignBytes'.
+--
+-- @since 0.0.1.0
+data SignedMessage = SignedMessage
+  { messageLength :: CSize
+  -- ^ Original message length
+  , messageForeignPtr :: ForeignPtr CUChar
+  , signatureForeignPtr :: ForeignPtr CUChar
+  }
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+      -- > display message = "SignedMessage { message = \"<contents>\", signature = \"<signature>\" }"
+    )
+    via (ShowInstance SignedMessage)
+
+-- | > show message = "SignedMessage { message = \"<contents>\", signature = \"<signature>\" }"
+--
+-- @since 0.0.3.0
+instance Show SignedMessage where
+  show msg = unsafeDupablePerformIO $ use $ do
+    message <- extractUnverifiedMessage msg
+    sig <- extractSignature msg
+    let showMessage = ByteString.unpackChars message
+        showSig = ByteString.unpackChars . Base16.extractBase16 . Base16.encodeBase16' $ sig
+    pure $
+      mconcat
+        [ "SignedMessage { message = \""
+        , showMessage
+        , "\", signature = \""
+        , showSig
+        , "\" }"
+        ]
+
+-- | By message length, then lexicographical comparison of message and
+-- signature pointer contents.
+--
+-- @since 0.0.1.0
+instance Eq SignedMessage where
+  (SignedMessage len1 msg1 sig1) == (SignedMessage len2 msg2 sig2) =
+    let
+      messageLength = len1 == len2
+      messageEq = foreignPtrEq msg1 msg2 len1
+      signatureEq = foreignPtrEq sig1 sig2 cryptoSignBytes
+     in
+      messageLength && messageEq && signatureEq
+
+-- | By message length, then lexicographical comparison of message and
+-- signature pointer contents.
+--
+-- @since 0.0.1.0
+instance Ord SignedMessage where
+  compare (SignedMessage len1 msg1 sig1) (SignedMessage len2 msg2 sig2) =
+    let
+      messageLength = compare len1 len2
+      messageOrd = foreignPtrOrd msg1 msg2 len1
+      signatureOrd = foreignPtrOrd sig1 sig2 cryptoSignBytes
+     in
+      messageLength <> messageOrd <> signatureOrd
+
+-- | Sign a message with a t'SecretKey'.
+sign :: SecretKey -> StrictByteString -> Scoped IO SignedMessage
+sign (SecretKey secretKeyForeignPtr) message = do
+  (cstring, messageLength) <- unsafeCStringLen message
+  messageForeignPtr <- mallocForeignPtrBytes messageLength
+  signatureForeignPtr <- mallocForeignPtrBytes (fromIntegral @CSize @Int cryptoSignBytes)
+  reset $ do
+    messagePtr <- foreignPtr messageForeignPtr
+    copyArray messagePtr (Foreign.castPtr @CChar @CUChar cstring) messageLength
+    signaturePtr <- foreignPtr signatureForeignPtr
+    secretKeyPtr <- foreignPtr secretKeyForeignPtr
+    lift $
+      cryptoSignDetached
+        signaturePtr
+        Foreign.nullPtr
+        (Foreign.castPtr @CChar @CUChar cstring)
+        (fromIntegral @Int @CULLong messageLength)
+        secretKeyPtr
+  pure
+    SignedMessage
+      { messageLength = fromIntegral @Int @CSize messageLength
+      , messageForeignPtr
+      , signatureForeignPtr
+      }
+
+-- | Result of detached signature verification.
+--
+-- @since 0.0.3.0
+data SignatureVerification a
+  = -- | The signature was created by the expected t'SecretKey'.
+    --
+    -- @since 0.0.3.0
+    Valid a
+  | -- | The signature was not created by the expected t'SecretKey'.
+    --
+    -- @since 0.0.3.0
+    Invalid
+  deriving stock
+    ( Eq
+      -- ^ @since 0.0.3.0
+    , Ord
+      -- ^ @since 0.0.3.0
+    , Show
+      -- ^ @since 0.0.3.0
+    , Functor
+      -- ^ @since 0.0.3.0
+    , Foldable
+      -- ^ @since 0.0.3.0
+    , Traversable
+      -- ^ @since 0.0.3.0
+    )
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+    )
+    via (ShowInstance (SignatureVerification a))
+
+-- | Verify that a message was signed by the t'SecretKey' corresponding
+-- to the given t'PublicKey'.
+--
+-- @since 0.0.3.0
+verify :: SignedMessage -> PublicKey -> Scoped IO (SignatureVerification SignedMessage)
+verify message (PublicKey publicKeyForeignPtr) = do
+  result <- reset $ do
+    publicKeyPtr <- foreignPtr publicKeyForeignPtr
+    signaturePtr <- foreignPtr message.signatureForeignPtr
+    messagePtr <- foreignPtr message.messageForeignPtr
+    lift $
+      cryptoSignVerifyDetached
+        signaturePtr
+        messagePtr
+        (fromIntegral @CSize @CULLong message.messageLength)
+        publicKeyPtr
+  pure $ if result == 0 then Valid message else Invalid
+
+-- | Attempt to extract the message from a t'SignedMessage', verifying
+-- that the message was signed with the t'SecretKey' corresponding to
+-- the given t'PublicKey'.
+--
+-- @since 0.0.3.0
+open :: SignedMessage -> PublicKey -> Scoped IO (SignatureVerification StrictByteString)
+open message key = traverse extractUnverifiedMessage =<< verify message key
+
+-- | Extract a part of a t'SignedMessage' without verifying the signature.
+--
+-- @since 0.0.3.0
+unverifiedExtract
+  :: (SignedMessage -> ForeignPtr CUChar)
+  -> CSize
+  -> SignedMessage
+  -> Scoped IO StrictByteString
+unverifiedExtract target fieldLength (target -> field) = do
+  fieldPtr <- foreignPtr field
+  bsPtr <- mallocBytes (fromIntegral fieldLength)
+  lift $ Foreign.copyBytes bsPtr fieldPtr (fromIntegral fieldLength)
+  lift $ do
+    ByteString.unsafePackMallocCStringLen
+      ( Foreign.castPtr @_ @CChar bsPtr
+      , fromIntegral fieldLength
+      )
+
+-- | Extract the message part of a t'SignedMessage' without verifying the signature.
+--
+-- @since 0.0.3.0
+extractUnverifiedMessage :: SignedMessage -> Scoped IO StrictByteString
+extractUnverifiedMessage msg = unverifiedExtract (.messageForeignPtr) msg.messageLength msg
+
+-- | Extract the signature part of a t'SignedMessage' without verifying the signature.
+--
+-- @since 0.0.3.0
+extractSignature :: SignedMessage -> Scoped IO StrictByteString
+extractSignature = unverifiedExtract (.signatureForeignPtr) cryptoSignBytes
+
+-- | Construct a t'SignedMessage' from the message contents and a detached signature.
+--
+-- @since 0.0.3.0
+buildSignedMessage :: StrictByteString -> StrictByteString -> Scoped IO SignedMessage
+buildSignedMessage message signature = do
+  (messageString, messageLength) <- unsafeCStringLen message
+  messageForeignPtr <- mallocForeignPtrBytes messageLength
+  signatureForeignPtr <- mallocForeignPtrBytes (fromIntegral cryptoSignBytes)
+  reset $ do
+    signatureString <- unsafeCString signature
+    messagePtr <- foreignPtr messageForeignPtr
+    signaturePtr <- foreignPtr signatureForeignPtr
+    copyArray messagePtr (Foreign.castPtr messageString) messageLength
+    copyArray signaturePtr (Foreign.castPtr signatureString) (fromIntegral cryptoSignBytes)
+  pure
+    SignedMessage
+      { messageLength = fromIntegral @Int @CSize messageLength
+      , messageForeignPtr
+      , signatureForeignPtr
+      }
+
+-- | Thrown when we fail to extract a t'PublicKey' from a t'SecretKey'.
+--
+-- @since 0.0.3.0
+data PublicKeyExtractionException = PublicKeyExtractionException
+  deriving stock
+    ( Eq
+      -- ^ @since 0.0.3.0
+    , Ord
+      -- ^ @since 0.0.3.0
+    , Show
+      -- ^ @since 0.0.3.0
+    )
+  deriving anyclass
+    ( Exception
+      -- ^ @since 0.0.3.0
+    )
+
+-- | Copy a hexadecimal-encoded bytestring to some key pointer.
+--
+-- Input is checked for encoding and length.
+--
+-- @since 0.0.3.0
+copyHexKey :: CSize -> StrictByteString -> Either KeyMaterialDecodeError (ForeignPtr CUChar)
+copyHexKey size bytes =
+  unsafeDupablePerformIO $
+    for (validKeyMaterial size bytes) (unsafeCopyToSodiumPointer size)

--- a/sel/src/Sel/PublicKey/Signature.hs
+++ b/sel/src/Sel/PublicKey/Signature.hs
@@ -1,240 +1,148 @@
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-
 -- |
 --
 -- Module: Sel.PublicKey.Signature
 -- Description: Public-key signatures with the Ed25519 algorithm
--- Copyright: (C) Hécate Moonlight 2022
+-- Copyright: (C) Hécate Moonlight 2022, Jack Henahan 2024
 -- License: BSD-3-Clause
 -- Maintainer: The Haskell Cryptography Group
 -- Portability: GHC only
 module Sel.PublicKey.Signature
-  ( -- ** Introduction
+  ( -- * Public-key Signatures
     -- $introduction
+
+    -- ** Public keys
+    -- $publicKeys
     PublicKey
+  , decodePublicKeyHexByteString
+  , encodePublicKeyHexByteString
+
+    -- ** Secret keys
+    -- $secretKeys
   , SecretKey
-  , SignedMessage
+  , decodeSecretKeyHexByteString
+  , publicKey
+
+    -- *** ⚠️ Handle with care
+  , unsafeEncodeSecretKeyHexByteString
 
     -- ** Key Pair generation
   , generateKeyPair
 
     -- ** Message Signing
+  , SignedMessage
   , signMessage
-  , openMessage
 
-    -- ** Constructing and Deconstructing
+    -- *** Inspecting signed messages
+  , openMessage
   , getSignature
   , unsafeGetMessage
+
+    -- *** Detached signatures
   , mkSignature
+
+    -- ** Exceptions
+  , PublicKeyExtractionException (..)
   )
 where
 
-import Control.Monad (void)
 import Data.ByteString (StrictByteString)
-import Data.ByteString.Unsafe (unsafePackMallocCStringLen)
-import qualified Data.ByteString.Unsafe as ByteString
-import Foreign
-  ( ForeignPtr
-  , Ptr
-  , castPtr
-  , mallocBytes
-  , mallocForeignPtrBytes
-  , withForeignPtr
-  )
-import Foreign.C (CChar, CSize, CUChar, CULLong)
-import qualified Foreign.Marshal.Array as Foreign
-import qualified Foreign.Ptr as Foreign
-import GHC.IO.Handle.Text (memcpy)
+import Sel.Internal.Scoped (use)
+import Sel.PublicKey.Internal.Signature
 import System.IO.Unsafe (unsafeDupablePerformIO)
-
-import LibSodium.Bindings.CryptoSign
-  ( cryptoSignBytes
-  , cryptoSignDetached
-  , cryptoSignKeyPair
-  , cryptoSignPublicKeyBytes
-  , cryptoSignSecretKeyBytes
-  , cryptoSignVerifyDetached
-  )
-import Sel.Internal
 
 -- $introduction
 --
--- Public-key Signatures work with a 'SecretKey' and 'PublicKey'
+-- Append a signature to any number of messages using a
+-- t'SecretKey'. Distribute a t'PublicKey' so third-parties can verify
+-- that the messages were signed with a particular t'SecretKey'.
 --
--- * The 'SecretKey' is used to append a signature to any number of messages. It must stay private;
--- * The 'PublicKey' is used by third-parties to to verify that the signature appended to a message was
--- issued by the creator of the public key. It must be distributed to third-parties.
+-- * The t'SecretKey' must stay private.
 --
--- Verifiers need to already know and ultimately trust a public key before messages signed
--- using it can be verified.
+-- * The t'PublicKey' is not a proof of identity, only control. Ensure
+-- that t'PublicKey's are trusted before verifying signatures.
 
--- |
+-- $publicKeys
 --
--- @since 0.0.1.0
-newtype PublicKey = PublicKey (ForeignPtr CUChar)
+-- Public keys are intended to be shared with any party or process
+-- which may need to verify that a given message was signed by a
+-- particular secret key.
+--
+-- === Human-readable output
+--
+-- * @'Data.Text.Display.display' :: t'PublicKey' -> 'Data.Text.Text'@, the hexadecimal encoding of the t'PublicKey' in a 'Data.Text.Text'
+-- * @'show' :: t'PublicKey' -> 'String'@, the hexadecimal encoding of the t'PublicKey' in a 'String'
 
--- |
+-- $secretKeys
 --
--- @since 0.0.1.0
-instance Eq PublicKey where
-  (PublicKey pk1) == (PublicKey pk2) =
-    foreignPtrEq pk1 pk2 cryptoSignPublicKeyBytes
-
--- |
+-- Secret keys are intended to be private and never shared without
+-- extreme care. Leaking a secret key allows anyone to impersonate the
+-- creator of that key and sign messages with their identity.
 --
--- @since 0.0.1.0
-instance Ord PublicKey where
-  compare (PublicKey pk1) (PublicKey pk2) =
-    foreignPtrOrd pk1 pk2 cryptoSignPublicKeyBytes
-
--- |
+-- If a secret key is compromised, all messages signed by that key
+-- should be considered compromised.
 --
--- @since 0.0.1.0
-newtype SecretKey = SecretKey (ForeignPtr CUChar)
-
--- |
+-- Secret keys are compared for equality using
+-- 'LibSodium.Bindings.Comparison.sodiumMemcmp' and lexicographically
+-- using 'LibSodium.Bindings.Comparison.sodiumCompare', both
+-- constant-time comparisons, to guard against timing attacks.
 --
--- @since 0.0.1.0
-instance Eq SecretKey where
-  (SecretKey sk1) == (SecretKey sk2) =
-    foreignPtrEqConstantTime sk1 sk2 cryptoSignSecretKeyBytes
-
--- |
+-- === ⚠️ Serialization
 --
--- @since 0.0.1.0
-instance Ord SecretKey where
-  compare (SecretKey sk1) (SecretKey sk2) =
-    foreignPtrOrd sk1 sk2 cryptoSignSecretKeyBytes
-
--- |
---
--- @since 0.0.1.0
-data SignedMessage = SignedMessage
-  { messageLength :: CSize
-  , messageForeignPtr :: ForeignPtr CUChar
-  , signatureForeignPtr :: ForeignPtr CUChar
-  }
-
--- |
---
--- @since 0.0.1.0
-instance Eq SignedMessage where
-  (SignedMessage len1 msg1 sig1) == (SignedMessage len2 msg2 sig2) =
-    let
-      messageLength = len1 == len2
-      msg1Eq = foreignPtrEq msg1 msg2 len1
-      msg2Eq = foreignPtrEq sig1 sig2 cryptoSignBytes
-     in
-      messageLength && msg1Eq && msg2Eq
-
--- |
---
--- @since 0.0.1.0
-instance Ord SignedMessage where
-  compare (SignedMessage len1 msg1 sig1) (SignedMessage len2 msg2 sig2) =
-    let
-      messageLength = compare len1 len2
-      msg1Ord = foreignPtrOrd msg1 msg2 len1
-      msg2Ord = foreignPtrOrd sig1 sig2 cryptoSignBytes
-     in
-      messageLength <> msg1Ord <> msg2Ord
+-- * @'unsafeEncodeSecretKeyHexByteString' :: t'SecretKey' -> 'StrictBytestring'@
 
 -- | Generate a pair of public and secret key.
 --
--- The length parameters used are 'cryptoSignPublicKeyBytes'
--- and 'cryptoSignSecretKeyBytes'.
+-- The length parameters used are 'LibSodium.Bindings.CryptoSign.cryptoSignPublicKeyBytes'
+-- and 'LibSodium.Bindings.CryptoSign.cryptoSignSecretKeyBytes'.
 --
 -- @since 0.0.1.0
 generateKeyPair :: IO (PublicKey, SecretKey)
-generateKeyPair = do
-  publicKeyForeignPtr <- mallocForeignPtrBytes (fromIntegral @CSize @Int cryptoSignPublicKeyBytes)
-  secretKeyForeignPtr <- mallocForeignPtrBytes (fromIntegral @CSize @Int cryptoSignSecretKeyBytes)
-  withForeignPtr publicKeyForeignPtr $ \pkPtr ->
-    withForeignPtr secretKeyForeignPtr $ \skPtr ->
-      void $
-        cryptoSignKeyPair
-          pkPtr
-          skPtr
-  pure (PublicKey publicKeyForeignPtr, SecretKey secretKeyForeignPtr)
+generateKeyPair = (,) <$> public <*> secret <$> keyPair
 
--- | Sign a message.
+-- | Sign a message with a t'SecretKey'.
+--
+-- === Example
+--
+-- Given @keys :: 'Traversable' t => t t'SecretKey'@ and @message ::
+-- 'StrictByteString'@, we can sign our message with each key.
+--
+-- @
+--   traverse (signMessage message) keys -- :: Traversable t => IO (t 'SignedMessage')
+--   -- or, equivalently
+--   for keys (signMessage message)
+-- @
 --
 -- @since 0.0.1.0
 signMessage :: StrictByteString -> SecretKey -> IO SignedMessage
-signMessage message (SecretKey skFPtr) =
-  ByteString.unsafeUseAsCStringLen message $ \(cString, messageLength) -> do
-    let sigLength = fromIntegral @CSize @Int cryptoSignBytes
-    (messageForeignPtr :: ForeignPtr CUChar) <- Foreign.mallocForeignPtrBytes messageLength
-    signatureForeignPtr <- Foreign.mallocForeignPtrBytes sigLength
-    withForeignPtr messageForeignPtr $ \messagePtr ->
-      withForeignPtr signatureForeignPtr $ \signaturePtr ->
-        withForeignPtr skFPtr $ \skPtr -> do
-          Foreign.copyArray messagePtr (Foreign.castPtr @CChar @CUChar cString) messageLength
-          void $
-            cryptoSignDetached
-              signaturePtr
-              Foreign.nullPtr -- Always of size 'cryptoSignBytes'
-              (castPtr @CChar @CUChar cString)
-              (fromIntegral @Int @CULLong messageLength)
-              skPtr
-    pure $ SignedMessage (fromIntegral @Int @CSize messageLength) messageForeignPtr signatureForeignPtr
+signMessage message secretKey = use $ sign secretKey message
 
--- | Open a signed message with the signatory's public key.
--- The function returns 'Nothing' if there is a key mismatch.
+-- | Attempt to extract the message from a t'SignedMessage', verifying
+-- that the message was signed with the t'SecretKey' corresponding to
+-- the given t'PublicKey'.
 --
 -- @since 0.0.1.0
 openMessage :: SignedMessage -> PublicKey -> Maybe StrictByteString
-openMessage SignedMessage{messageLength, messageForeignPtr, signatureForeignPtr} (PublicKey pkForeignPtr) = unsafeDupablePerformIO $
-  withForeignPtr pkForeignPtr $ \publicKeyPtr ->
-    withForeignPtr signatureForeignPtr $ \signaturePtr -> do
-      withForeignPtr messageForeignPtr $ \messagePtr -> do
-        result <-
-          cryptoSignVerifyDetached
-            signaturePtr
-            messagePtr
-            (fromIntegral @CSize @CULLong messageLength)
-            publicKeyPtr
-        case result of
-          (-1) -> pure Nothing
-          _ -> do
-            bsPtr <- mallocBytes (fromIntegral messageLength)
-            memcpy bsPtr (castPtr messagePtr) messageLength
-            Just <$> unsafePackMallocCStringLen (castPtr bsPtr :: Ptr CChar, fromIntegral messageLength)
+openMessage message key =
+  case unsafeDupablePerformIO . use $ open message key of
+    Valid msg -> Just msg
+    Invalid -> Nothing
 
--- | Get the signature part of a 'SignedMessage'.
+-- | Get the signature part of a t'SignedMessage'.
 --
 -- @since 0.0.1.0
 getSignature :: SignedMessage -> StrictByteString
-getSignature SignedMessage{signatureForeignPtr} = unsafeDupablePerformIO $
-  withForeignPtr signatureForeignPtr $ \signaturePtr -> do
-    bsPtr <- Foreign.mallocBytes (fromIntegral cryptoSignBytes)
-    memcpy bsPtr signaturePtr cryptoSignBytes
-    unsafePackMallocCStringLen (Foreign.castPtr bsPtr :: Ptr CChar, fromIntegral cryptoSignBytes)
+getSignature = unsafeDupablePerformIO . use . extractSignature
 
--- | Get the message part of a 'SignedMessage' __without verifying the signature__.
+-- | Get the message part of a t'SignedMessage' __without verifying the signature__.
 --
 -- @since 0.0.1.0
 unsafeGetMessage :: SignedMessage -> StrictByteString
-unsafeGetMessage SignedMessage{messageLength, messageForeignPtr} = unsafeDupablePerformIO $
-  withForeignPtr messageForeignPtr $ \messagePtr -> do
-    bsPtr <- Foreign.mallocBytes (fromIntegral messageLength)
-    memcpy bsPtr messagePtr messageLength
-    unsafePackMallocCStringLen (Foreign.castPtr bsPtr :: Ptr CChar, fromIntegral messageLength)
+unsafeGetMessage = unsafeDupablePerformIO . use . extractUnverifiedMessage
 
--- | Combine a message and a signature into a 'SignedMessage'.
+-- | Construct a signed message from a message and a detached signature.
 --
 -- @since 0.0.1.0
 mkSignature :: StrictByteString -> StrictByteString -> SignedMessage
-mkSignature message signature = unsafeDupablePerformIO $
-  ByteString.unsafeUseAsCStringLen message $ \(messageStringPtr, messageLength) ->
-    ByteString.unsafeUseAsCStringLen signature $ \(signatureStringPtr, _) -> do
-      (messageForeignPtr :: ForeignPtr CUChar) <- Foreign.mallocForeignPtrBytes messageLength
-      signatureForeignPtr <- Foreign.mallocForeignPtrBytes (fromIntegral cryptoSignBytes)
-      withForeignPtr messageForeignPtr $ \messagePtr ->
-        withForeignPtr signatureForeignPtr $ \signaturePtr -> do
-          Foreign.copyArray messagePtr (Foreign.castPtr messageStringPtr) messageLength
-          Foreign.copyArray signaturePtr (Foreign.castPtr signatureStringPtr) (fromIntegral cryptoSignBytes)
-      pure $ SignedMessage (fromIntegral @Int @CSize messageLength) messageForeignPtr signatureForeignPtr
+mkSignature messageBytes signatureBytes =
+  unsafeDupablePerformIO . use $
+    buildSignedMessage messageBytes signatureBytes

--- a/sel/test/Test/PublicKey/Signature.hs
+++ b/sel/test/Test/PublicKey/Signature.hs
@@ -5,20 +5,84 @@ module Test.PublicKey.Signature where
 import Sel.PublicKey.Signature
 import Test.Tasty
 import Test.Tasty.HUnit
+import TestUtils
 
 spec :: TestTree
-spec =
-  testGroup
-    "Signing tests"
-    [ testCase "Sign a message with a public key and decrypt it with a secret key" testSignMessage
-    ]
+spec = withKeyPair $ \kp ->
+  testGroup "Signature" $
+    sequence [serdes, signing] kp
 
-testSignMessage :: Assertion
-testSignMessage = do
-  (publicKey, secretKey) <- generateKeyPair
-  signedMessage <- signMessage "hello hello" secretKey
-  let result = openMessage signedMessage publicKey
+serdes :: IO (PublicKey, SecretKey) -> TestTree
+serdes kp =
+  testGroup "Key pair serdes" $
+    keyPairCases
+      kp
+      [ ("Public key round-trip", publicKeyRoundTrip)
+      , ("Secret key round-trip", secretKeyRoundTrip)
+      , ("Public key extraction", publicKeyExtraction)
+      ]
+
+signing :: IO (PublicKey, SecretKey) -> TestTree
+signing kp =
+  testGroup "Message signing" $
+    keyPairCases
+      kp
+      [ ("Sign and open with the same key", signAndOpenSelf)
+      , ("Sign and open with another key", signAndOpenOther)
+      , ("Detached signature round-trip", signRoundTrip)
+      ]
+
+keyPairCases :: IO (PublicKey, SecretKey) -> [(String, (PublicKey, SecretKey) -> Assertion)] -> [TestTree]
+keyPairCases = fmap . uncurry . usingKeyPair
+
+withKeyPair :: (IO (PublicKey, SecretKey) -> TestTree) -> TestTree
+withKeyPair = withResource generateKeyPair mempty
+
+usingKeyPair :: IO (PublicKey, SecretKey) -> String -> ((PublicKey, SecretKey) -> Assertion) -> TestTree
+usingKeyPair kp testName test = testCase testName (test =<< kp)
+
+publicKeyRoundTrip :: (PublicKey, SecretKey) -> Assertion
+publicKeyRoundTrip (public, _) = do
+  let encoded = encodePublicKeyHexByteString public
+  decoded <- assertRight $ decodePublicKeyHexByteString encoded
+  assertEqual "Public key hex decode" public decoded
+
+secretKeyRoundTrip :: (PublicKey, SecretKey) -> Assertion
+secretKeyRoundTrip (_, secret) = do
+  let encoded = unsafeEncodeSecretKeyHexByteString secret
+  decoded <- assertRight $ decodeSecretKeyHexByteString encoded
+  assertEqual "Secret key hex decode" secret decoded
+
+publicKeyExtraction :: (PublicKey, SecretKey) -> Assertion
+publicKeyExtraction (public, secret) =
+  assertEqual "Public key extraction" public (publicKey secret)
+
+signAndOpenSelf :: (PublicKey, SecretKey) -> Assertion
+signAndOpenSelf (public, secret) = do
+  let message = "SIGNED"
+  signed <- signMessage message secret
+  let result = openMessage signed public
   assertEqual
-    "Message is well-opened with the correct key"
-    (Just "hello hello")
+    "Open self-signed message"
+    (Just message)
     result
+
+signAndOpenOther :: (PublicKey, SecretKey) -> Assertion
+signAndOpenOther (_, secret) = do
+  let message = "SIGNED"
+  (otherPublic, _) <- generateKeyPair
+  signed <- signMessage message secret
+  let result = openMessage signed otherPublic
+  assertEqual
+    "Fail to open with another key"
+    Nothing
+    result
+
+signRoundTrip :: (PublicKey, SecretKey) -> Assertion
+signRoundTrip (_, secret) = do
+  let message = "SIGNED"
+  signed <- signMessage message secret
+  let unverified = unsafeGetMessage signed
+      detachedSignature = getSignature signed
+      reconstructed = mkSignature unverified detachedSignature
+  assertEqual "Round trip" signed reconstructed

--- a/sel/test/package-api-9.10.1.txt
+++ b/sel/test/package-api-9.10.1.txt
@@ -1,0 +1,476 @@
+
+module Sel where
+  secureMain :: forall a. GHC.Types.IO a -> GHC.Types.IO a
+  secureMainWithError :: forall a. GHC.Types.IO a -> GHC.Types.IO a -> GHC.Types.IO a
+
+module Sel.HMAC where
+
+
+module Sel.HMAC.SHA256 where
+  type AuthenticationKey :: *
+  newtype AuthenticationKey = ...
+  type AuthenticationTag :: *
+  newtype AuthenticationTag = ...
+  type role Multipart nominal
+  type Multipart :: * -> *
+  newtype Multipart s = ...
+  authenticate :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> AuthenticationKey -> GHC.Types.IO AuthenticationTag
+  authenticationKeyFromHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text AuthenticationKey
+  authenticationTagFromHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text AuthenticationTag
+  authenticationTagToBinary :: AuthenticationTag -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  authenticationTagToHexByteString :: AuthenticationTag -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  newAuthenticationKey :: GHC.Types.IO AuthenticationKey
+  unsafeAuthenticationKeyToBinary :: AuthenticationKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  unsafeAuthenticationKeyToHexByteString :: AuthenticationKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  updateMultipart :: forall s. Multipart s -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.IO ()
+  verify :: AuthenticationTag -> AuthenticationKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.Bool
+  withMultipart :: forall a (m :: * -> *). Control.Monad.IO.Class.MonadIO m => AuthenticationKey -> (forall s. Multipart s -> m a) -> m AuthenticationTag
+
+module Sel.HMAC.SHA512 where
+  type AuthenticationKey :: *
+  newtype AuthenticationKey = ...
+  type AuthenticationTag :: *
+  newtype AuthenticationTag = ...
+  type role Multipart nominal
+  type Multipart :: * -> *
+  newtype Multipart s = ...
+  authenticate :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> AuthenticationKey -> GHC.Types.IO AuthenticationTag
+  authenticationKeyFromHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text AuthenticationKey
+  authenticationTagFromHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text AuthenticationTag
+  authenticationTagToBinary :: AuthenticationTag -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  authenticationTagToHexByteString :: AuthenticationTag -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  newAuthenticationKey :: GHC.Types.IO AuthenticationKey
+  unsafeAuthenticationKeyToBinary :: AuthenticationKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  unsafeAuthenticationKeyToHexByteString :: AuthenticationKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  updateMultipart :: forall s. Multipart s -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.IO ()
+  verify :: AuthenticationTag -> AuthenticationKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.Bool
+  withMultipart :: forall a (m :: * -> *). Control.Monad.IO.Class.MonadIO m => AuthenticationKey -> (forall s. Multipart s -> m a) -> m AuthenticationTag
+
+module Sel.HMAC.SHA512_256 where
+  type AuthenticationKey :: *
+  newtype AuthenticationKey = ...
+  type AuthenticationTag :: *
+  newtype AuthenticationTag = ...
+  type role Multipart nominal
+  type Multipart :: * -> *
+  newtype Multipart s = ...
+  authenticate :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> AuthenticationKey -> GHC.Types.IO AuthenticationTag
+  authenticationKeyFromHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text AuthenticationKey
+  authenticationTagFromHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text AuthenticationTag
+  authenticationTagToBinary :: AuthenticationTag -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  authenticationTagToHexByteString :: AuthenticationTag -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  newAuthenticationKey :: GHC.Types.IO AuthenticationKey
+  unsafeAuthenticationKeyToBinary :: AuthenticationKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  unsafeAuthenticationKeyToHexByteString :: AuthenticationKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  updateMultipart :: forall s. Multipart s -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.IO ()
+  verify :: AuthenticationTag -> AuthenticationKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.Bool
+  withMultipart :: forall a (m :: * -> *). Control.Monad.IO.Class.MonadIO m => AuthenticationKey -> (forall s. Multipart s -> m a) -> m AuthenticationTag
+
+module Sel.Hashing where
+  type Hash :: *
+  newtype Hash = ...
+  type HashKey :: *
+  newtype HashKey = ...
+  type role Multipart nominal
+  type Multipart :: * -> *
+  newtype Multipart s = ...
+  hashByteString :: GHC.Internal.Maybe.Maybe HashKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.IO Hash
+  hashToBinary :: Hash -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  hashToHexByteString :: Hash -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  hashToHexText :: Hash -> Data.Text.Internal.Text
+  newHashKey :: GHC.Types.IO HashKey
+  updateMultipart :: forall (m :: * -> *) s. Control.Monad.IO.Class.MonadIO m => Multipart s -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> m ()
+  withMultipart :: forall a (m :: * -> *). Control.Monad.IO.Class.MonadIO m => GHC.Internal.Maybe.Maybe HashKey -> (forall s. Multipart s -> m a) -> m Hash
+
+module Sel.Hashing.Password where
+  type Argon2Params :: *
+  data Argon2Params = Argon2Params {...}
+  type PasswordHash :: *
+  newtype PasswordHash = ...
+  type Salt :: *
+  newtype Salt = ...
+  asciiByteStringToPasswordHash :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> PasswordHash
+  asciiTextToPasswordHash :: Data.Text.Internal.Text -> PasswordHash
+  binaryToSalt :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Maybe.Maybe Salt
+  defaultArgon2Params :: Argon2Params
+  genSalt :: GHC.Types.IO Salt
+  hashByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.IO PasswordHash
+  hashByteStringWithParams :: Argon2Params -> Salt -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.IO PasswordHash
+  hashText :: Data.Text.Internal.Text -> GHC.Types.IO PasswordHash
+  hexByteStringToSalt :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Maybe.Maybe Salt
+  hexTextToSalt :: Data.Text.Internal.Text -> GHC.Internal.Maybe.Maybe Salt
+  passwordHashToByteString :: PasswordHash -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  passwordHashToHexByteString :: PasswordHash -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  passwordHashToHexText :: PasswordHash -> Data.Text.Internal.Text
+  passwordHashToText :: PasswordHash -> Data.Text.Internal.Text
+  saltToBinary :: Salt -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  saltToHexByteString :: Salt -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  saltToHexText :: Salt -> Data.Text.Internal.Text
+  verifyByteString :: PasswordHash -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.Bool
+  verifyText :: PasswordHash -> Data.Text.Internal.Text -> GHC.Types.Bool
+
+module Sel.Hashing.SHA256 where
+  type Hash :: *
+  newtype Hash = ...
+  type role Multipart nominal
+  type Multipart :: * -> *
+  newtype Multipart s = ...
+  hashByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.IO Hash
+  hashText :: Data.Text.Internal.Text -> GHC.Types.IO Hash
+  hashToBinary :: Hash -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  hashToHexByteString :: Hash -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  hashToHexText :: Hash -> Data.Text.Internal.Text
+  updateMultipart :: forall s. Multipart s -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.IO ()
+  withMultipart :: forall a (m :: * -> *). Control.Monad.IO.Class.MonadIO m => (forall s. Multipart s -> m a) -> m Hash
+
+module Sel.Hashing.SHA512 where
+  type Hash :: *
+  newtype Hash = ...
+  type role Multipart nominal
+  type Multipart :: * -> *
+  newtype Multipart s = ...
+  hashByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.IO Hash
+  hashText :: Data.Text.Internal.Text -> GHC.Types.IO Hash
+  hashToBinary :: Hash -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  hashToHexByteString :: Hash -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  hashToHexText :: Hash -> Data.Text.Internal.Text
+  updateMultipart :: forall s. Multipart s -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.IO ()
+  withMultipart :: forall a (m :: * -> *). Control.Monad.IO.Class.MonadIO m => (forall s. Multipart s -> m a) -> m Hash
+
+module Sel.Hashing.Short where
+  type ShortHash :: *
+  newtype ShortHash = ...
+  type ShortHashKey :: *
+  newtype ShortHashKey = ...
+  type ShortHashingException :: *
+  data ShortHashingException = ShortHashingException
+  binaryToShortHashKey :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Maybe.Maybe ShortHashKey
+  hashByteString :: ShortHashKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.IO ShortHash
+  hashText :: ShortHashKey -> Data.Text.Internal.Text -> GHC.Types.IO ShortHash
+  hexByteStringToShortHashKey :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Maybe.Maybe ShortHashKey
+  hexTextToShortHashKey :: Data.Text.Internal.Text -> GHC.Internal.Maybe.Maybe ShortHashKey
+  newKey :: GHC.Types.IO ShortHashKey
+  shortHashKeyToBinary :: ShortHashKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  shortHashKeyToHexByteString :: ShortHashKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  shortHashKeyToHexText :: ShortHashKey -> Data.Text.Internal.Text
+  shortHashToBinary :: ShortHash -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  shortHashToHexByteString :: ShortHash -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  shortHashToHexText :: ShortHash -> Data.Text.Internal.Text
+
+module Sel.KeyMaterialDecodeError where
+  type InputLength :: *
+  newtype InputLength = InputLength GHC.Types.Int
+  type KeyMaterialDecodeError :: *
+  data KeyMaterialDecodeError = ByteLengthMismatch RequiredLength InputLength | DecodingFailure Data.Text.Internal.Text
+  type RequiredLength :: *
+  newtype RequiredLength = RequiredLength GHC.Types.Int
+  validKeyMaterial :: GHC.Internal.Foreign.C.Types.CSize -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either KeyMaterialDecodeError bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+
+module Sel.PublicKey.Cipher where
+  type CipherText :: *
+  data CipherText = CipherText {messageLength :: GHC.Internal.Foreign.C.Types.CULLong, cipherTextForeignPtr :: GHC.Internal.ForeignPtr.ForeignPtr GHC.Internal.Foreign.C.Types.CUChar}
+  type EncryptionError :: *
+  data EncryptionError = EncryptionError
+  type KeyPairGenerationException :: *
+  data KeyPairGenerationException = KeyPairGenerationException
+  type Nonce :: *
+  newtype Nonce = Nonce (GHC.Internal.ForeignPtr.ForeignPtr GHC.Internal.Foreign.C.Types.CUChar)
+  type PublicKey :: *
+  newtype PublicKey = PublicKey (GHC.Internal.ForeignPtr.ForeignPtr GHC.Internal.Foreign.C.Types.CUChar)
+  type SecretKey :: *
+  newtype SecretKey = SecretKey (GHC.Internal.ForeignPtr.ForeignPtr GHC.Internal.Foreign.C.Types.CUChar)
+  cipherTextFromHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text CipherText
+  cipherTextToBinary :: CipherText -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  cipherTextToHexByteString :: CipherText -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  cipherTextToHexText :: CipherText -> Data.Text.Internal.Text
+  decrypt :: CipherText -> PublicKey -> SecretKey -> Nonce -> GHC.Internal.Maybe.Maybe bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  encrypt :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> PublicKey -> SecretKey -> GHC.Types.IO (Nonce, CipherText)
+  keyPairFromHexByteStrings :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text (PublicKey, SecretKey)
+  newKeyPair :: GHC.Types.IO (PublicKey, SecretKey)
+  nonceFromHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text Nonce
+  nonceToHexByteString :: Nonce -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  publicKeyToHexByteString :: PublicKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  unsafeSecretKeyToHexByteString :: SecretKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+
+module Sel.PublicKey.Seal where
+  type EncryptionError :: *
+  data EncryptionError = ...
+  type KeyPairGenerationException :: *
+  data KeyPairGenerationException = ...
+  type PublicKey :: *
+  newtype PublicKey = PublicKey (GHC.Internal.ForeignPtr.ForeignPtr GHC.Internal.Foreign.C.Types.CUChar)
+  type SecretKey :: *
+  newtype SecretKey = SecretKey (GHC.Internal.ForeignPtr.ForeignPtr GHC.Internal.Foreign.C.Types.CUChar)
+  newKeyPair :: GHC.Types.IO (PublicKey, SecretKey)
+  open :: Sel.PublicKey.Cipher.CipherText -> PublicKey -> SecretKey -> GHC.Internal.Maybe.Maybe bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  seal :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> PublicKey -> GHC.Types.IO Sel.PublicKey.Cipher.CipherText
+
+module Sel.PublicKey.Signature where
+  type PublicKey :: *
+  newtype PublicKey = ...
+  type PublicKeyExtractionException :: *
+  data PublicKeyExtractionException = PublicKeyExtractionException
+  type SecretKey :: *
+  newtype SecretKey = ...
+  type SignedMessage :: *
+  data SignedMessage = ...
+  decodePublicKeyHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Sel.KeyMaterialDecodeError.KeyMaterialDecodeError PublicKey
+  decodeSecretKeyHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Sel.KeyMaterialDecodeError.KeyMaterialDecodeError SecretKey
+  encodePublicKeyHexByteString :: PublicKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  generateKeyPair :: GHC.Types.IO (PublicKey, SecretKey)
+  getSignature :: SignedMessage -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  mkSignature :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> SignedMessage
+  openMessage :: SignedMessage -> PublicKey -> GHC.Internal.Maybe.Maybe bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  publicKey :: SecretKey -> PublicKey
+  signMessage :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> SecretKey -> GHC.Types.IO SignedMessage
+  unsafeEncodeSecretKeyHexByteString :: SecretKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  unsafeGetMessage :: SignedMessage -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+
+module Sel.Scrypt where
+  type ScryptHash :: *
+  newtype ScryptHash = ...
+  asciiByteStringToScryptHash :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> ScryptHash
+  asciiTextToScryptHash :: Data.Text.Internal.Text -> ScryptHash
+  scryptHashPassword :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.IO ScryptHash
+  scryptHashToByteString :: ScryptHash -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  scryptHashToText :: ScryptHash -> Data.Text.Internal.Text
+  scryptVerifyPassword :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> ScryptHash -> GHC.Types.IO GHC.Types.Bool
+
+module Sel.SecretKey.Authentication where
+  type AuthenticationKey :: *
+  newtype AuthenticationKey = ...
+  type AuthenticationTag :: *
+  newtype AuthenticationTag = ...
+  authenticate :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> AuthenticationKey -> GHC.Types.IO AuthenticationTag
+  authenticationKeyFromHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text AuthenticationKey
+  authenticationTagFromHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text AuthenticationTag
+  authenticationTagToHexByteString :: AuthenticationTag -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  newAuthenticationKey :: GHC.Types.IO AuthenticationKey
+  unsafeAuthenticationKeyToHexByteString :: AuthenticationKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  verify :: AuthenticationTag -> AuthenticationKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Types.Bool
+
+module Sel.SecretKey.Cipher where
+  type Hash :: *
+  data Hash = ...
+  type Nonce :: *
+  newtype Nonce = ...
+  type SecretKey :: *
+  newtype SecretKey = ...
+  decrypt :: Hash -> SecretKey -> Nonce -> GHC.Internal.Maybe.Maybe bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  encrypt :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> SecretKey -> GHC.Types.IO (Nonce, Hash)
+  hashFromHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text Hash
+  hashToBinary :: Hash -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  hashToHexByteString :: Hash -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  hashToHexText :: Hash -> Data.Text.Internal.Text
+  newSecretKey :: GHC.Types.IO SecretKey
+  nonceFromHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text Nonce
+  nonceToHexByteString :: Nonce -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  secretKeyFromHexByteString :: bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text SecretKey
+  unsafeSecretKeyToHexByteString :: SecretKey -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+
+module Sel.SecretKey.Stream where
+  type CipherText :: *
+  data CipherText = ...
+  type Header :: *
+  newtype Header = ...
+  type MessageTag :: *
+  data MessageTag = Message | Final | Push | Rekey
+  type role Multipart nominal
+  type Multipart :: * -> *
+  newtype Multipart s = ...
+  type SecretKey :: *
+  newtype SecretKey = ...
+  type StreamDecryptionException :: *
+  data StreamDecryptionException = ...
+  type StreamEncryptionException :: *
+  data StreamEncryptionException = ...
+  type StreamInitEncryptionException :: *
+  data StreamInitEncryptionException = ...
+  ciphertextFromHexByteString :: base16-1.0:Data.Base16.Types.Internal.Base16 bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text CipherText
+  ciphertextToBinary :: CipherText -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  ciphertextToHexByteString :: CipherText -> base16-1.0:Data.Base16.Types.Internal.Base16 bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  ciphertextToHexText :: CipherText -> base16-1.0:Data.Base16.Types.Internal.Base16 Data.Text.Internal.Text
+  decryptChunk :: forall (m :: * -> *) s. Control.Monad.IO.Class.MonadIO m => Multipart s -> CipherText -> m bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  decryptList :: forall (m :: * -> *). Control.Monad.IO.Class.MonadIO m => SecretKey -> Header -> [CipherText] -> m (GHC.Internal.Maybe.Maybe [bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString])
+  decryptStream :: forall a (m :: * -> *). Control.Monad.IO.Class.MonadIO m => SecretKey -> Header -> (forall s. Multipart s -> m a) -> m (GHC.Internal.Maybe.Maybe a)
+  encryptChunk :: forall (m :: * -> *) s. Control.Monad.IO.Class.MonadIO m => Multipart s -> MessageTag -> bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> m CipherText
+  encryptList :: forall (m :: * -> *). Control.Monad.IO.Class.MonadIO m => SecretKey -> [bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString] -> m (Header, [CipherText])
+  encryptStream :: forall a (m :: * -> *). Control.Monad.IO.Class.MonadIO m => SecretKey -> (forall s. Multipart s -> m a) -> m (Header, a)
+  headerFromHexByteString :: base16-1.0:Data.Base16.Types.Internal.Base16 bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text Header
+  headerToHexByteString :: Header -> base16-1.0:Data.Base16.Types.Internal.Base16 bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+  newSecretKey :: GHC.Types.IO SecretKey
+  secretKeyFromHexByteString :: base16-1.0:Data.Base16.Types.Internal.Base16 bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString -> GHC.Internal.Data.Either.Either Data.Text.Internal.Text SecretKey
+  unsafeSecretKeyToHexByteString :: SecretKey -> base16-1.0:Data.Base16.Types.Internal.Base16 bytestring-0.12.1.0:Data.ByteString.Internal.Type.StrictByteString
+
+
+-- Instances:
+instance GHC.Internal.Base.Functor sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SignatureVerification -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Internal.Data.Foldable.Foldable sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SignatureVerification -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Internal.Data.Traversable.Traversable sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SignatureVerification -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Internal.Exception.Type.Exception Sel.Hashing.Short.ShortHashingException -- Defined in ‘Sel.Hashing.Short’
+instance GHC.Internal.Exception.Type.Exception Sel.KeyMaterialDecodeError.KeyMaterialDecodeError -- Defined in ‘Sel.KeyMaterialDecodeError’
+instance GHC.Internal.Exception.Type.Exception Sel.PublicKey.Cipher.EncryptionError -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Internal.Exception.Type.Exception Sel.PublicKey.Cipher.KeyPairGenerationException -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Internal.Exception.Type.Exception sel-0.0.3.0:Sel.PublicKey.Internal.Signature.PublicKeyExtractionException -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Internal.Exception.Type.Exception Sel.SecretKey.Stream.StreamDecryptionException -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Internal.Exception.Type.Exception Sel.SecretKey.Stream.StreamEncryptionException -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Internal.Exception.Type.Exception Sel.SecretKey.Stream.StreamInitEncryptionException -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Internal.Foreign.Storable.Storable Sel.Hashing.Hash -- Defined in ‘Sel.Hashing’
+instance GHC.Internal.Foreign.Storable.Storable Sel.Hashing.SHA256.Hash -- Defined in ‘Sel.Hashing.SHA256’
+instance GHC.Internal.Foreign.Storable.Storable Sel.Hashing.SHA512.Hash -- Defined in ‘Sel.Hashing.SHA512’
+instance GHC.Internal.Generics.Generic Sel.Hashing.Password.PasswordHash -- Defined in ‘Sel.Hashing.Password’
+instance GHC.Internal.Show.Show Sel.HMAC.SHA256.AuthenticationKey -- Defined in ‘Sel.HMAC.SHA256’
+instance GHC.Internal.Show.Show Sel.HMAC.SHA256.AuthenticationTag -- Defined in ‘Sel.HMAC.SHA256’
+instance GHC.Internal.Show.Show Sel.HMAC.SHA512.AuthenticationKey -- Defined in ‘Sel.HMAC.SHA512’
+instance GHC.Internal.Show.Show Sel.HMAC.SHA512.AuthenticationTag -- Defined in ‘Sel.HMAC.SHA512’
+instance GHC.Internal.Show.Show Sel.HMAC.SHA512_256.AuthenticationKey -- Defined in ‘Sel.HMAC.SHA512_256’
+instance GHC.Internal.Show.Show Sel.HMAC.SHA512_256.AuthenticationTag -- Defined in ‘Sel.HMAC.SHA512_256’
+instance GHC.Internal.Show.Show Sel.Hashing.Hash -- Defined in ‘Sel.Hashing’
+instance GHC.Internal.Show.Show Sel.Hashing.Password.PasswordHash -- Defined in ‘Sel.Hashing.Password’
+instance GHC.Internal.Show.Show Sel.Hashing.Password.Salt -- Defined in ‘Sel.Hashing.Password’
+instance GHC.Internal.Show.Show Sel.Hashing.SHA256.Hash -- Defined in ‘Sel.Hashing.SHA256’
+instance GHC.Internal.Show.Show Sel.Hashing.SHA512.Hash -- Defined in ‘Sel.Hashing.SHA512’
+instance GHC.Internal.Show.Show Sel.Hashing.Short.ShortHash -- Defined in ‘Sel.Hashing.Short’
+instance GHC.Internal.Show.Show Sel.Hashing.Short.ShortHashKey -- Defined in ‘Sel.Hashing.Short’
+instance GHC.Internal.Show.Show Sel.Hashing.Short.ShortHashingException -- Defined in ‘Sel.Hashing.Short’
+instance GHC.Internal.Show.Show Sel.KeyMaterialDecodeError.InputLength -- Defined in ‘Sel.KeyMaterialDecodeError’
+instance GHC.Internal.Show.Show Sel.KeyMaterialDecodeError.KeyMaterialDecodeError -- Defined in ‘Sel.KeyMaterialDecodeError’
+instance GHC.Internal.Show.Show Sel.KeyMaterialDecodeError.RequiredLength -- Defined in ‘Sel.KeyMaterialDecodeError’
+instance GHC.Internal.Show.Show Sel.PublicKey.Cipher.CipherText -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Internal.Show.Show Sel.PublicKey.Cipher.EncryptionError -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Internal.Show.Show Sel.PublicKey.Cipher.KeyPairGenerationException -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Internal.Show.Show Sel.PublicKey.Cipher.Nonce -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Internal.Show.Show Sel.PublicKey.Cipher.PublicKey -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Internal.Show.Show Sel.PublicKey.Cipher.SecretKey -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Internal.Show.Show sel-0.0.3.0:Sel.PublicKey.Internal.Signature.KeyPair -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Internal.Show.Show sel-0.0.3.0:Sel.PublicKey.Internal.Signature.PublicKey -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Internal.Show.Show sel-0.0.3.0:Sel.PublicKey.Internal.Signature.PublicKeyExtractionException -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Internal.Show.Show sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SecretKey -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance forall a. GHC.Internal.Show.Show a => GHC.Internal.Show.Show (sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SignatureVerification a) -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Internal.Show.Show sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SignedMessage -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Internal.Show.Show Sel.Scrypt.ScryptHash -- Defined in ‘Sel.Scrypt’
+instance GHC.Internal.Show.Show Sel.SecretKey.Authentication.AuthenticationKey -- Defined in ‘Sel.SecretKey.Authentication’
+instance GHC.Internal.Show.Show Sel.SecretKey.Authentication.AuthenticationTag -- Defined in ‘Sel.SecretKey.Authentication’
+instance GHC.Internal.Show.Show Sel.SecretKey.Cipher.Hash -- Defined in ‘Sel.SecretKey.Cipher’
+instance GHC.Internal.Show.Show Sel.SecretKey.Cipher.Nonce -- Defined in ‘Sel.SecretKey.Cipher’
+instance GHC.Internal.Show.Show Sel.SecretKey.Cipher.SecretKey -- Defined in ‘Sel.SecretKey.Cipher’
+instance GHC.Internal.Show.Show Sel.SecretKey.Stream.CipherText -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Internal.Show.Show Sel.SecretKey.Stream.Header -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Internal.Show.Show Sel.SecretKey.Stream.SecretKey -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Internal.Show.Show Sel.SecretKey.Stream.StreamDecryptionException -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Internal.Show.Show Sel.SecretKey.Stream.StreamEncryptionException -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Internal.Show.Show Sel.SecretKey.Stream.StreamInitEncryptionException -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Classes.Eq Sel.HMAC.SHA256.AuthenticationKey -- Defined in ‘Sel.HMAC.SHA256’
+instance GHC.Classes.Eq Sel.HMAC.SHA256.AuthenticationTag -- Defined in ‘Sel.HMAC.SHA256’
+instance GHC.Classes.Eq Sel.HMAC.SHA512.AuthenticationKey -- Defined in ‘Sel.HMAC.SHA512’
+instance GHC.Classes.Eq Sel.HMAC.SHA512.AuthenticationTag -- Defined in ‘Sel.HMAC.SHA512’
+instance GHC.Classes.Eq Sel.HMAC.SHA512_256.AuthenticationKey -- Defined in ‘Sel.HMAC.SHA512_256’
+instance GHC.Classes.Eq Sel.HMAC.SHA512_256.AuthenticationTag -- Defined in ‘Sel.HMAC.SHA512_256’
+instance GHC.Classes.Eq Sel.Hashing.Hash -- Defined in ‘Sel.Hashing’
+instance GHC.Classes.Eq Sel.Hashing.HashKey -- Defined in ‘Sel.Hashing’
+instance GHC.Classes.Eq Sel.Hashing.Password.PasswordHash -- Defined in ‘Sel.Hashing.Password’
+instance GHC.Classes.Eq Sel.Hashing.Password.Salt -- Defined in ‘Sel.Hashing.Password’
+instance GHC.Classes.Eq Sel.Hashing.SHA256.Hash -- Defined in ‘Sel.Hashing.SHA256’
+instance GHC.Classes.Eq Sel.Hashing.SHA512.Hash -- Defined in ‘Sel.Hashing.SHA512’
+instance GHC.Classes.Eq Sel.Hashing.Short.ShortHash -- Defined in ‘Sel.Hashing.Short’
+instance GHC.Classes.Eq Sel.Hashing.Short.ShortHashKey -- Defined in ‘Sel.Hashing.Short’
+instance GHC.Classes.Eq Sel.Hashing.Short.ShortHashingException -- Defined in ‘Sel.Hashing.Short’
+instance GHC.Classes.Eq Sel.KeyMaterialDecodeError.InputLength -- Defined in ‘Sel.KeyMaterialDecodeError’
+instance GHC.Classes.Eq Sel.KeyMaterialDecodeError.KeyMaterialDecodeError -- Defined in ‘Sel.KeyMaterialDecodeError’
+instance GHC.Classes.Eq Sel.KeyMaterialDecodeError.RequiredLength -- Defined in ‘Sel.KeyMaterialDecodeError’
+instance GHC.Classes.Eq Sel.PublicKey.Cipher.CipherText -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Classes.Eq Sel.PublicKey.Cipher.EncryptionError -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Classes.Eq Sel.PublicKey.Cipher.KeyPairGenerationException -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Classes.Eq Sel.PublicKey.Cipher.Nonce -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Classes.Eq Sel.PublicKey.Cipher.PublicKey -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Classes.Eq Sel.PublicKey.Cipher.SecretKey -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Classes.Eq sel-0.0.3.0:Sel.PublicKey.Internal.Signature.KeyPair -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Classes.Eq sel-0.0.3.0:Sel.PublicKey.Internal.Signature.PublicKey -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Classes.Eq sel-0.0.3.0:Sel.PublicKey.Internal.Signature.PublicKeyExtractionException -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Classes.Eq sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SecretKey -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance forall a. GHC.Classes.Eq a => GHC.Classes.Eq (sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SignatureVerification a) -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Classes.Eq sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SignedMessage -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Classes.Eq Sel.Scrypt.ScryptHash -- Defined in ‘Sel.Scrypt’
+instance GHC.Classes.Eq Sel.SecretKey.Authentication.AuthenticationKey -- Defined in ‘Sel.SecretKey.Authentication’
+instance GHC.Classes.Eq Sel.SecretKey.Authentication.AuthenticationTag -- Defined in ‘Sel.SecretKey.Authentication’
+instance GHC.Classes.Eq Sel.SecretKey.Cipher.Hash -- Defined in ‘Sel.SecretKey.Cipher’
+instance GHC.Classes.Eq Sel.SecretKey.Cipher.Nonce -- Defined in ‘Sel.SecretKey.Cipher’
+instance GHC.Classes.Eq Sel.SecretKey.Cipher.SecretKey -- Defined in ‘Sel.SecretKey.Cipher’
+instance GHC.Classes.Eq Sel.SecretKey.Stream.CipherText -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Classes.Eq Sel.SecretKey.Stream.Header -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Classes.Eq Sel.SecretKey.Stream.SecretKey -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Classes.Eq Sel.SecretKey.Stream.StreamDecryptionException -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Classes.Eq Sel.SecretKey.Stream.StreamEncryptionException -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Classes.Eq Sel.SecretKey.Stream.StreamInitEncryptionException -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Classes.Ord Sel.HMAC.SHA256.AuthenticationKey -- Defined in ‘Sel.HMAC.SHA256’
+instance GHC.Classes.Ord Sel.HMAC.SHA256.AuthenticationTag -- Defined in ‘Sel.HMAC.SHA256’
+instance GHC.Classes.Ord Sel.HMAC.SHA512.AuthenticationKey -- Defined in ‘Sel.HMAC.SHA512’
+instance GHC.Classes.Ord Sel.HMAC.SHA512.AuthenticationTag -- Defined in ‘Sel.HMAC.SHA512’
+instance GHC.Classes.Ord Sel.HMAC.SHA512_256.AuthenticationKey -- Defined in ‘Sel.HMAC.SHA512_256’
+instance GHC.Classes.Ord Sel.HMAC.SHA512_256.AuthenticationTag -- Defined in ‘Sel.HMAC.SHA512_256’
+instance GHC.Classes.Ord Sel.Hashing.Hash -- Defined in ‘Sel.Hashing’
+instance GHC.Classes.Ord Sel.Hashing.HashKey -- Defined in ‘Sel.Hashing’
+instance GHC.Classes.Ord Sel.Hashing.Password.PasswordHash -- Defined in ‘Sel.Hashing.Password’
+instance GHC.Classes.Ord Sel.Hashing.Password.Salt -- Defined in ‘Sel.Hashing.Password’
+instance GHC.Classes.Ord Sel.Hashing.SHA256.Hash -- Defined in ‘Sel.Hashing.SHA256’
+instance GHC.Classes.Ord Sel.Hashing.SHA512.Hash -- Defined in ‘Sel.Hashing.SHA512’
+instance GHC.Classes.Ord Sel.Hashing.Short.ShortHash -- Defined in ‘Sel.Hashing.Short’
+instance GHC.Classes.Ord Sel.Hashing.Short.ShortHashKey -- Defined in ‘Sel.Hashing.Short’
+instance GHC.Classes.Ord Sel.Hashing.Short.ShortHashingException -- Defined in ‘Sel.Hashing.Short’
+instance GHC.Classes.Ord Sel.PublicKey.Cipher.CipherText -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Classes.Ord Sel.PublicKey.Cipher.EncryptionError -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Classes.Ord Sel.PublicKey.Cipher.KeyPairGenerationException -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Classes.Ord Sel.PublicKey.Cipher.Nonce -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Classes.Ord Sel.PublicKey.Cipher.PublicKey -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Classes.Ord Sel.PublicKey.Cipher.SecretKey -- Defined in ‘Sel.PublicKey.Cipher’
+instance GHC.Classes.Ord sel-0.0.3.0:Sel.PublicKey.Internal.Signature.KeyPair -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Classes.Ord sel-0.0.3.0:Sel.PublicKey.Internal.Signature.PublicKey -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Classes.Ord sel-0.0.3.0:Sel.PublicKey.Internal.Signature.PublicKeyExtractionException -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Classes.Ord sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SecretKey -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance forall a. GHC.Classes.Ord a => GHC.Classes.Ord (sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SignatureVerification a) -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Classes.Ord sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SignedMessage -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance GHC.Classes.Ord Sel.Scrypt.ScryptHash -- Defined in ‘Sel.Scrypt’
+instance GHC.Classes.Ord Sel.SecretKey.Authentication.AuthenticationKey -- Defined in ‘Sel.SecretKey.Authentication’
+instance GHC.Classes.Ord Sel.SecretKey.Authentication.AuthenticationTag -- Defined in ‘Sel.SecretKey.Authentication’
+instance GHC.Classes.Ord Sel.SecretKey.Cipher.Hash -- Defined in ‘Sel.SecretKey.Cipher’
+instance GHC.Classes.Ord Sel.SecretKey.Cipher.Nonce -- Defined in ‘Sel.SecretKey.Cipher’
+instance GHC.Classes.Ord Sel.SecretKey.Cipher.SecretKey -- Defined in ‘Sel.SecretKey.Cipher’
+instance GHC.Classes.Ord Sel.SecretKey.Stream.CipherText -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Classes.Ord Sel.SecretKey.Stream.Header -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Classes.Ord Sel.SecretKey.Stream.SecretKey -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Classes.Ord Sel.SecretKey.Stream.StreamDecryptionException -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Classes.Ord Sel.SecretKey.Stream.StreamEncryptionException -- Defined in ‘Sel.SecretKey.Stream’
+instance GHC.Classes.Ord Sel.SecretKey.Stream.StreamInitEncryptionException -- Defined in ‘Sel.SecretKey.Stream’
+instance Data.Text.Display.Core.Display Sel.HMAC.SHA256.AuthenticationKey -- Defined in ‘Sel.HMAC.SHA256’
+instance Data.Text.Display.Core.Display Sel.HMAC.SHA256.AuthenticationTag -- Defined in ‘Sel.HMAC.SHA256’
+instance Data.Text.Display.Core.Display Sel.HMAC.SHA512.AuthenticationKey -- Defined in ‘Sel.HMAC.SHA512’
+instance Data.Text.Display.Core.Display Sel.HMAC.SHA512.AuthenticationTag -- Defined in ‘Sel.HMAC.SHA512’
+instance Data.Text.Display.Core.Display Sel.HMAC.SHA512_256.AuthenticationKey -- Defined in ‘Sel.HMAC.SHA512_256’
+instance Data.Text.Display.Core.Display Sel.HMAC.SHA512_256.AuthenticationTag -- Defined in ‘Sel.HMAC.SHA512_256’
+instance Data.Text.Display.Core.Display Sel.Hashing.Hash -- Defined in ‘Sel.Hashing’
+instance Data.Text.Display.Core.Display Sel.Hashing.Password.PasswordHash -- Defined in ‘Sel.Hashing.Password’
+instance Data.Text.Display.Core.Display Sel.Hashing.Password.Salt -- Defined in ‘Sel.Hashing.Password’
+instance Data.Text.Display.Core.Display Sel.Hashing.SHA256.Hash -- Defined in ‘Sel.Hashing.SHA256’
+instance Data.Text.Display.Core.Display Sel.Hashing.SHA512.Hash -- Defined in ‘Sel.Hashing.SHA512’
+instance Data.Text.Display.Core.Display Sel.Hashing.Short.ShortHash -- Defined in ‘Sel.Hashing.Short’
+instance Data.Text.Display.Core.Display Sel.Hashing.Short.ShortHashKey -- Defined in ‘Sel.Hashing.Short’
+instance Data.Text.Display.Core.Display Sel.Hashing.Short.ShortHashingException -- Defined in ‘Sel.Hashing.Short’
+instance Data.Text.Display.Core.Display Sel.KeyMaterialDecodeError.KeyMaterialDecodeError -- Defined in ‘Sel.KeyMaterialDecodeError’
+instance Data.Text.Display.Core.Display Sel.PublicKey.Cipher.CipherText -- Defined in ‘Sel.PublicKey.Cipher’
+instance Data.Text.Display.Core.Display Sel.PublicKey.Cipher.Nonce -- Defined in ‘Sel.PublicKey.Cipher’
+instance Data.Text.Display.Core.Display Sel.PublicKey.Cipher.PublicKey -- Defined in ‘Sel.PublicKey.Cipher’
+instance Data.Text.Display.Core.Display Sel.PublicKey.Cipher.SecretKey -- Defined in ‘Sel.PublicKey.Cipher’
+instance Data.Text.Display.Core.Display sel-0.0.3.0:Sel.PublicKey.Internal.Signature.KeyPair -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance Data.Text.Display.Core.Display sel-0.0.3.0:Sel.PublicKey.Internal.Signature.PublicKey -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance Data.Text.Display.Core.Display sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SecretKey -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance forall a. GHC.Internal.Show.Show a => Data.Text.Display.Core.Display (sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SignatureVerification a) -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance Data.Text.Display.Core.Display sel-0.0.3.0:Sel.PublicKey.Internal.Signature.SignedMessage -- Defined in ‘sel-0.0.3.0:Sel.PublicKey.Internal.Signature’
+instance Data.Text.Display.Core.Display Sel.Scrypt.ScryptHash -- Defined in ‘Sel.Scrypt’
+instance Data.Text.Display.Core.Display Sel.SecretKey.Authentication.AuthenticationKey -- Defined in ‘Sel.SecretKey.Authentication’
+instance Data.Text.Display.Core.Display Sel.SecretKey.Authentication.AuthenticationTag -- Defined in ‘Sel.SecretKey.Authentication’
+instance Data.Text.Display.Core.Display Sel.SecretKey.Cipher.Hash -- Defined in ‘Sel.SecretKey.Cipher’
+instance Data.Text.Display.Core.Display Sel.SecretKey.Cipher.Nonce -- Defined in ‘Sel.SecretKey.Cipher’
+instance Data.Text.Display.Core.Display Sel.SecretKey.Cipher.SecretKey -- Defined in ‘Sel.SecretKey.Cipher’
+instance Data.Text.Display.Core.Display Sel.SecretKey.Stream.CipherText -- Defined in ‘Sel.SecretKey.Stream’
+instance Data.Text.Display.Core.Display Sel.SecretKey.Stream.Header -- Defined in ‘Sel.SecretKey.Stream’
+instance Data.Text.Display.Core.Display Sel.SecretKey.Stream.SecretKey -- Defined in ‘Sel.SecretKey.Stream’


### PR DESCRIPTION
Public API
----------

- Adds `KeyMaterialDecodeError` to signal issues during deserialization

- Adds serde functions for public and secret keys

- Adds a function to extract the public key from a secret key, with `PublicKeyExtraction` on failure

- Adds `Show` and `Display` instances for `PublicKey`, `SecretKey`, and `SignedMessage`

- Re-exports `PublicKey`, `SecretKey`, and `SignedMessage` from the internal module, but no other visible change

- Expands documentation

Internals
---------

- Moves signature internals to an internal module using the new `Scoped` machinery; this is only _really_ required because we need to get at the raw pointers to do anything interesting, but the guts don't need to be on display for the public API; if this is disagreeable, it can be moved wholesale into the public module

- Adds a (presently only internal) mechanism for tracking verification of signatures; this is intended to become public as part of an [RFC][RFC] on the API, but remains internal (and may even be removed) pending feedback

- Adds `KeyPair`, just a name for the existing `(PublicKey, SecretKey)` representation; this is also intended to become public as part of the [RFC][RFC]

[RFC]: https://github.com/haskell-cryptography/libsodium-bindings/issues/174