### PR TITLE
feat: add constant time hex encoding

### DIFF
--- a/sel/CHANGELOG.md
+++ b/sel/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## sel-0.0.3.0
 
+* Add constant time hex encoding [#176](https://github.com/haskell-cryptography/libsodium-bindings/pull/176)
 * Support `text-display` 1.0.0.0
 * Replace usages of `memcpy` with `Foreign.copyBytes` [#172](https://github.com/haskell-cryptography/libsodium-bindings/pull/172)
 * Add constant-time pointer comparison [#171](https://github.com/haskell-cryptography/libsodium-bindings/pull/171)

--- a/sel/sel.cabal
+++ b/sel/sel.cabal
@@ -66,6 +66,7 @@ library
     Sel.Internal
     Sel.Internal.Scoped
     Sel.Internal.Scoped.Foreign
+    Sel.Internal.Sodium
 
   build-depends:
     , base                 >=4.14   && <5

--- a/sel/src/Sel/HMAC/SHA512.hs
+++ b/sel/src/Sel/HMAC/SHA512.hs
@@ -52,7 +52,6 @@ module Sel.HMAC.SHA512
 
 import Control.Monad (void, when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import qualified Data.Base16.Types as Base16
 import Data.ByteString (StrictByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as Base16
@@ -82,6 +81,7 @@ import LibSodium.Bindings.SHA2
   )
 import LibSodium.Bindings.SecureMemory (finalizerSodiumFree, sodiumMalloc)
 import Sel.Internal (allocateWith, foreignPtrEqConstantTime, foreignPtrOrdConstantTime)
+import Sel.Internal.Sodium (binaryToHex)
 
 -- $introduction
 -- The 'authenticate' function computes an authentication tag for a message and a secret key,
@@ -316,14 +316,14 @@ unsafeAuthenticationKeyToBinary (AuthenticationKey authenticationKeyForeignPtr) 
     (Foreign.castForeignPtr @CUChar @Word8 authenticationKeyForeignPtr)
     (fromIntegral @CSize @Int cryptoAuthHMACSHA512KeyBytes)
 
--- | Convert a 'AuthenticationKey to a hexadecimal-encoded 'StrictByteString'.
+-- | Convert a 'AuthenticationKey to a hexadecimal-encoded 'StrictByteString' in constant time.
 --
 -- ⚠️  Be prudent as to where you store it!
 --
 -- @since 0.0.1.0
 unsafeAuthenticationKeyToHexByteString :: AuthenticationKey -> StrictByteString
-unsafeAuthenticationKeyToHexByteString =
-  Base16.extractBase16 . Base16.encodeBase16' . unsafeAuthenticationKeyToBinary
+unsafeAuthenticationKeyToHexByteString (AuthenticationKey authenticationKeyForeignPtr) =
+  binaryToHex authenticationKeyForeignPtr cryptoAuthHMACSHA512KeyBytes
 
 -- | A secret authentication key of size 'cryptoAuthHMACSHA512Bytes'.
 --
@@ -355,14 +355,12 @@ instance Ord AuthenticationTag where
 instance Show AuthenticationTag where
   show = BS.unpackChars . authenticationTagToHexByteString
 
--- | Convert an 'AuthenticationTag' to a hexadecimal-encoded 'StrictByteString'.
+-- | Convert an 'AuthenticationTag' to a hexadecimal-encoded 'StrictByteString' in constant time.
 --
 -- @since 0.0.1.0
 authenticationTagToHexByteString :: AuthenticationTag -> StrictByteString
-authenticationTagToHexByteString authenticationTag =
-  Base16.extractBase16 $
-    Base16.encodeBase16' $
-      authenticationTagToBinary authenticationTag
+authenticationTagToHexByteString (AuthenticationTag authenticationTagForeignPtr) =
+  binaryToHex authenticationTagForeignPtr cryptoAuthHMACSHA512Bytes
 
 -- | Convert an 'AuthenticationTag' to a binary 'StrictByteString'.
 --

--- a/sel/src/Sel/HMAC/SHA512_256.hs
+++ b/sel/src/Sel/HMAC/SHA512_256.hs
@@ -80,6 +80,7 @@ import LibSodium.Bindings.SHA2
   )
 import LibSodium.Bindings.SecureMemory (finalizerSodiumFree, sodiumMalloc)
 import Sel.Internal (allocateWith, foreignPtrEqConstantTime, foreignPtrOrdConstantTime)
+import Sel.Internal.Sodium (binaryToHex)
 
 -- $introduction
 -- The 'authenticate' function computes an authentication tag for a message and a secret key,
@@ -315,14 +316,14 @@ unsafeAuthenticationKeyToBinary (AuthenticationKey authenticationKeyForeignPtr) 
       (Foreign.castForeignPtr @CUChar @Word8 authenticationKeyForeignPtr)
       (fromIntegral @CSize @Int cryptoAuthHMACSHA512256KeyBytes)
 
--- | Convert a 'AuthenticationKey to a hexadecimal-encoded 'StrictByteString'.
+-- | Convert a 'AuthenticationKey to a hexadecimal-encoded 'StrictByteString' in constant time.
 --
 -- ⚠️  Be prudent as to where you store it!
 --
 -- @since 0.0.1.0
 unsafeAuthenticationKeyToHexByteString :: AuthenticationKey -> StrictByteString
-unsafeAuthenticationKeyToHexByteString =
-  Base16.extractBase16 . Base16.encodeBase16' . unsafeAuthenticationKeyToBinary
+unsafeAuthenticationKeyToHexByteString (AuthenticationKey authenticationKeyForeignPtr) =
+  binaryToHex authenticationKeyForeignPtr cryptoAuthHMACSHA512256KeyBytes
 
 -- | A secret authentication key of size 'cryptoAuthHMACSHA512256Bytes'.
 --
@@ -354,14 +355,12 @@ instance Ord AuthenticationTag where
 instance Show AuthenticationTag where
   show = BS.unpackChars . authenticationTagToHexByteString
 
--- | Convert an 'AuthenticationTag' to a hexadecimal-encoded 'StrictByteString'.
+-- | Convert an 'AuthenticationTag' to a hexadecimal-encoded 'StrictByteString' in constant time.
 --
 -- @since 0.0.1.0
 authenticationTagToHexByteString :: AuthenticationTag -> StrictByteString
-authenticationTagToHexByteString authenticationTag =
-  Base16.extractBase16 $
-    Base16.encodeBase16' $
-      authenticationTagToBinary authenticationTag
+authenticationTagToHexByteString (AuthenticationTag authenticationTagForeignPtr) =
+  binaryToHex authenticationTagForeignPtr cryptoAuthHMACSHA512256Bytes
 
 -- | Convert an 'AuthenticationTag' to a binary 'StrictByteString'.
 --

--- a/sel/src/Sel/Hashing.hs
+++ b/sel/src/Sel/Hashing.hs
@@ -65,6 +65,7 @@ import LibSodium.Bindings.GenericHashing
   , cryptoGenericHashUpdate
   )
 import Sel.Internal
+import Sel.Internal.Sodium (binaryToHex)
 
 -- $introduction
 --
@@ -203,11 +204,11 @@ hashByteString mHashKey bytestring =
 hashToHexText :: Hash -> Text
 hashToHexText = Base16.extractBase16 . Base16.encodeBase16 . hashToBinary
 
--- | Convert a 'Hash' to a strict, hexadecimal-encoded 'StrictByteString'.
+-- | Convert a 'Hash' to a strict, hexadecimal-encoded 'StrictByteString' in constant time.
 --
 -- @since 0.0.1.0
 hashToHexByteString :: Hash -> StrictByteString
-hashToHexByteString = Base16.extractBase16 . Base16.encodeBase16' . hashToBinary
+hashToHexByteString (Hash hashPtr) = binaryToHex hashPtr cryptoGenericHashBytes
 
 -- | Convert a 'Hash' to a strict binary 'StrictByteString'.
 --

--- a/sel/src/Sel/Hashing/Password.hs
+++ b/sel/src/Sel/Hashing/Password.hs
@@ -73,6 +73,7 @@ import qualified Data.Base16.Types as Base16
 import GHC.Generics
 import LibSodium.Bindings.PasswordHashing
 import LibSodium.Bindings.Random
+import Sel.Internal.Sodium (binaryToHex)
 
 -- $introduction
 --
@@ -216,13 +217,14 @@ passwordHashToText passwordHash =
           let !errPos = BS.length bs - BS.length suffix
            in error $ "decodeASCII: detected non-ASCII codepoint " ++ show word ++ " at position " ++ show errPos <> ". " <> show bs
 
--- | Convert a 'PasswordHash' to a hexadecimal-encoded 'StrictByteString'.
+-- | Convert a 'PasswordHash' to a hexadecimal-encoded 'StrictByteString' in constant time.
 --
 -- It is recommended to use this one on a 'PasswordHash' produced by 'hashByteStringWithParams'.
 --
 -- @since 0.0.1.0
 passwordHashToHexByteString :: PasswordHash -> StrictByteString
-passwordHashToHexByteString = Base16.extractBase16 . Base16.encodeBase16' . passwordHashToByteString
+passwordHashToHexByteString (PasswordHash passwordHashForeignPtr) =
+  binaryToHex (Foreign.castForeignPtr @CChar @CUChar passwordHashForeignPtr) cryptoPWHashStrBytes
 
 -- | Convert a 'PasswordHash' to a strict hexadecimal-encoded 'Text'.
 --

--- a/sel/src/Sel/Hashing/SHA256.hs
+++ b/sel/src/Sel/Hashing/SHA256.hs
@@ -58,6 +58,7 @@ import Control.Monad.IO.Class (MonadIO (liftIO))
 import qualified Data.Base16.Types as Base16
 import Data.Kind (Type)
 import Sel.Internal
+import Sel.Internal.Sodium (binaryToHex)
 
 -- $usage
 --
@@ -155,11 +156,12 @@ hashText text = hashByteString (Text.encodeUtf8 text)
 hashToHexText :: Hash -> Text
 hashToHexText = Base16.extractBase16 . Base16.encodeBase16 . hashToBinary
 
--- | Convert a 'Hash' to a strict, hexadecimal-encoded 'StrictByteString'.
+-- | Convert a 'Hash' to a strict, hexadecimal-encoded 'StrictByteString' in constant time.
 --
 -- @since 0.0.1.0
 hashToHexByteString :: Hash -> StrictByteString
-hashToHexByteString = Base16.extractBase16 . Base16.encodeBase16' . hashToBinary
+hashToHexByteString (Hash hashForeignPtr) =
+  binaryToHex hashForeignPtr cryptoHashSHA256Bytes
 
 -- | Convert a 'Hash' to a binary 'StrictByteString'.
 --

--- a/sel/src/Sel/Hashing/SHA512.hs
+++ b/sel/src/Sel/Hashing/SHA512.hs
@@ -58,6 +58,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Data.Base16.Types as Base16
 import Data.Kind (Type)
 import Sel.Internal
+import Sel.Internal.Sodium (binaryToHex)
 
 -- $usage
 --
@@ -134,11 +135,12 @@ instance Show Hash where
 hashToHexText :: Hash -> Text
 hashToHexText = Base16.extractBase16 . Base16.encodeBase16 . hashToBinary
 
--- | Convert a 'Hash' to a strict, hexadecimal-encoded 'StrictByteString'.
+-- | Convert a 'Hash' to a strict, hexadecimal-encoded 'StrictByteString' in constant time.
 --
 -- @since 0.0.1.0
 hashToHexByteString :: Hash -> StrictByteString
-hashToHexByteString = Base16.extractBase16 . Base16.encodeBase16' . hashToBinary
+hashToHexByteString (Hash hashForeignPtr) =
+  binaryToHex hashForeignPtr cryptoHashSHA512Bytes
 
 -- | Convert a 'Hash' to a binary 'StrictByteString'.
 --

--- a/sel/src/Sel/Hashing/Short.hs
+++ b/sel/src/Sel/Hashing/Short.hs
@@ -66,6 +66,7 @@ import LibSodium.Bindings.ShortHashing
   , cryptoShortHashX24KeyGen
   )
 import Sel.Internal
+import Sel.Internal.Sodium (binaryToHex)
 
 -- $introduction
 --
@@ -161,11 +162,12 @@ shortHashToBinary (ShortHash hashFPtr) =
     0
     (fromIntegral @CSize @Int cryptoShortHashSipHashX24Bytes)
 
--- | Convert a 'ShortHash' to a hexadecimal-encoded 'StrictByteString'.
+-- | Convert a 'ShortHash' to a hexadecimal-encoded 'StrictByteString' in constant time.
 --
 -- @since 0.0.1.0
 shortHashToHexByteString :: ShortHash -> StrictByteString
-shortHashToHexByteString = Base16.extractBase16 . Base16.encodeBase16' . shortHashToBinary
+shortHashToHexByteString (ShortHash hashForeignPtr) =
+  binaryToHex hashForeignPtr cryptoShortHashSipHashX24Bytes
 
 -- | Convert a 'ShortHash' to a strict hexadecimal-encoded 'Text'.
 --
@@ -224,11 +226,12 @@ shortHashKeyToBinary (ShortHashKey hashKeyFPtr) =
     0
     (fromIntegral @CSize @Int cryptoShortHashSipHashX24KeyBytes)
 
--- | Convert a 'ShortHash' to a hexadecimal-encoded 'StrictByteString'.
+-- | Convert a 'ShortHashKey' to a hexadecimal-encoded 'StrictByteString' in constant time.
 --
 -- @since 0.0.1.0
 shortHashKeyToHexByteString :: ShortHashKey -> StrictByteString
-shortHashKeyToHexByteString = Base16.extractBase16 . Base16.encodeBase16' . shortHashKeyToBinary
+shortHashKeyToHexByteString (ShortHashKey hashKeyForeignPtr) =
+  binaryToHex hashKeyForeignPtr cryptoShortHashSipHashX24KeyBytes
 
 -- | Convert a 'ShortHash' to a strict hexadecimal-encoded 'Text'.
 --

--- a/sel/src/Sel/Internal/Sodium.hs
+++ b/sel/src/Sel/Internal/Sodium.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+
+module Sel.Internal.Sodium where
+
+import Control.Monad.Trans.Class (lift)
+import Data.ByteString (StrictByteString)
+import Data.ByteString qualified as ByteString
+import Foreign (ForeignPtr)
+import Foreign.C (CSize, CUChar)
+import LibSodium.Bindings.Utils
+import Sel.Internal.Scoped
+import Sel.Internal.Scoped.Foreign
+import System.IO.Unsafe (unsafeDupablePerformIO)
+
+-- | Convert a byte array to a hexadecimal-encoded 'StrictByteString' in constant time.
+--
+-- /See:/ [@sodium_bin2hex@](https://libsodium.gitbook.io/doc/helpers#hexadecimal-encoding-decoding)
+--
+-- @since 0.0.3.0
+binaryToHex :: ForeignPtr CUChar -> CSize -> StrictByteString
+binaryToHex fPtr size = unsafeDupablePerformIO . use $ do
+  let hexLength = size * 2 + 1
+  hexPtr <- foreignPtr =<< mallocForeignPtrBytes (fromIntegral hexLength)
+  ptr <- foreignPtr fPtr
+  lift $ ByteString.packCString =<< sodiumBin2Hex hexPtr hexLength ptr size

--- a/sel/src/Sel/Scrypt.hs
+++ b/sel/src/Sel/Scrypt.hs
@@ -38,6 +38,7 @@ import Foreign hiding (void)
 import Foreign.C
 import LibSodium.Bindings.Scrypt
 import Sel.Internal
+import Sel.Internal.Sodium (binaryToHex)
 
 -- $introduction
 --
@@ -115,12 +116,12 @@ scryptVerifyPassword bytestring (ScryptHash sh) = do
           (fromIntegral cStringLen)
       return (result == 0)
 
--- | Convert a 'ScryptHash' to a binary 'StrictByteString'.
+-- | Convert a 'ScryptHash' to a binary 'StrictByteString' in constant time.
 --
 -- @since 0.0.1.0
 scryptHashToByteString :: ScryptHash -> StrictByteString
 scryptHashToByteString (ScryptHash fPtr) =
-  BS.fromForeignPtr0 (Foreign.castForeignPtr fPtr) (fromIntegral @CSize @Int cryptoPWHashScryptSalsa208SHA256StrBytes)
+  binaryToHex (Foreign.castForeignPtr @CChar @CUChar fPtr) cryptoPWHashScryptSalsa208SHA256StrBytes
 
 -- | Convert a 'ScryptHash' to a hexadecimal-encoded 'Text'.
 --


### PR DESCRIPTION
Pretty much what it says on the tin. Adds a higher-level wrapper around the [sodium_bin2hex()](https://libsodium.gitbook.io/doc/helpers#hexadecimal-encoding-decoding) binding, and uses the wrapper to implement all functions meant to produce a hexadecimal-encoded bytestring.